### PR TITLE
Feature/Put charging profile

### DIFF
--- a/00_Base/package.json
+++ b/00_Base/package.json
@@ -32,8 +32,8 @@
     "@types/lodash.startcase": "^4.4.9"
   },
   "dependencies": {
-    "@citrineos/base": "1.2.3",
-    "@citrineos/data": "1.2.3",
+    "@citrineos/base": "1.3.0",
+    "@citrineos/data": "1.3.0",
     "@typescript-eslint/eslint-plugin": "^6.5.0",
     "ajv": "^8.12.0",
     "class-transformer": "^0.5.1",

--- a/00_Base/src/index.ts
+++ b/00_Base/src/index.ts
@@ -43,6 +43,7 @@ export { OcpiResponse } from './model/ocpi.response';
 export { CommandResponse } from './model/CommandResponse';
 export { ChargingProfileResponse } from './model/ChargingProfileResponse';
 export { CommandResultType } from './model/CommandResult';
+export { SetChargingProfile } from './model/SetChargingProfile'
 
 export { VersionRepository } from './repository/version.repository';
 

--- a/00_Base/src/index.ts
+++ b/00_Base/src/index.ts
@@ -63,6 +63,7 @@ export { LoggingMiddleware } from './util/middleware/logging.middleware';
 
 export { BaseClientApi } from './trigger/BaseClientApi';
 export { CommandsClientApi } from './trigger/CommandsClientApi';
+export { ChargingProfilesClientApi } from './trigger/ChargingProfilesClientApi';
 export { ResponseSchema } from './openapi-spec-helper/decorators';
 
 export { CommandsService } from './services/commands.service';

--- a/00_Base/src/model/ChargingProfile.ts
+++ b/00_Base/src/model/ChargingProfile.ts
@@ -1,7 +1,6 @@
 import {
   IsArray,
   IsDateString,
-  IsDivisibleBy,
   IsInt,
   IsNotEmpty,
   IsNumber,
@@ -26,8 +25,7 @@ export class ChargingProfile {
   @IsNotEmpty()
   charging_rate_unit!: string;
 
-  @IsDivisibleBy(0.1)
-  @IsNumber()
+  @IsNumber({ maxDecimalPlaces: 1 })
   @Optional()
   min_charging_rate?: number | null;
 

--- a/00_Base/src/model/ChargingProfilePeriod.ts
+++ b/00_Base/src/model/ChargingProfilePeriod.ts
@@ -1,12 +1,11 @@
-import { IsDivisibleBy, IsInt, IsNotEmpty, IsNumber } from 'class-validator';
+import { IsInt, IsNotEmpty, IsNumber } from 'class-validator';
 
 export class ChargingProfilePeriod {
   @IsInt()
   @IsNotEmpty()
   start_period!: number;
 
-  @IsDivisibleBy(0.1)
-  @IsNumber()
+  @IsNumber({ maxDecimalPlaces: 1 })
   @IsNotEmpty()
   limit!: number;
 }

--- a/00_Base/src/services/charging-profiles.service.ts
+++ b/00_Base/src/services/charging-profiles.service.ts
@@ -1,3 +1,4 @@
+import {SetChargingProfile} from "../model/SetChargingProfile";
 import { Service } from 'typedi';
 import { CommandExecutor } from '../util/CommandExecutor';
 import { OcpiResponse } from '../model/ocpi.response';
@@ -9,16 +10,22 @@ export class ChargingProfilesService {
 
   constructor(private commandExecutor: CommandExecutor) {}
 
-  async getActiveChargingProfile(
-    sessionId: string,
-    duration: number,
-    responseUrl: string,
-  ): Promise<OcpiResponse<ChargingProfileResponse>> {
-    this.commandExecutor.executeGetActiveChargingProfile(
-      sessionId,
-      duration,
-      responseUrl,
-    );
-    return new OcpiResponse<ChargingProfileResponse>();
-  }
+    async getActiveChargingProfile(
+        sessionId: string,
+        duration: number,
+        responseUrl: string,
+    ): Promise<OcpiResponse<ChargingProfileResponse>> {
+        this.commandExecutor.executeGetActiveChargingProfile(
+            sessionId,
+            duration,
+            responseUrl,
+        );
+        return new OcpiResponse<ChargingProfileResponse>();
+    }
+
+    async putChargingProfile(sessionId: string, setChargingProfile: SetChargingProfile): Promise<OcpiResponse<ChargingProfileResponse>> {
+        this.commandExecutor.executePutChargingProfile(sessionId, setChargingProfile);
+        return new OcpiResponse<ChargingProfileResponse>();
+    }
+
 }

--- a/00_Base/src/services/charging-profiles.service.ts
+++ b/00_Base/src/services/charging-profiles.service.ts
@@ -1,9 +1,9 @@
-import {SetChargingProfile} from "../model/SetChargingProfile";
-import {Service} from 'typedi';
-import {CommandExecutor} from '../util/CommandExecutor';
-import {OcpiResponse} from '../model/ocpi.response';
-import {ChargingProfileResponse, ChargingProfileResponseType} from '../model/ChargingProfileResponse';
-import {NotFoundException} from "../exception/not.found.exception";
+import { SetChargingProfile } from "../model/SetChargingProfile";
+import { Service } from 'typedi';
+import { CommandExecutor } from '../util/CommandExecutor';
+import { OcpiResponse } from '../model/ocpi.response';
+import { ChargingProfileResponse, ChargingProfileResponseType } from '../model/ChargingProfileResponse';
+import { NotFoundException } from "../exception/not.found.exception";
 import {
     buildGenericServerErrorResponse,
     buildGenericSuccessResponse,

--- a/00_Base/src/trigger/ChargingProfilesClientApi.ts
+++ b/00_Base/src/trigger/ChargingProfilesClientApi.ts
@@ -1,0 +1,16 @@
+import { BaseClientApi } from './BaseClientApi';
+import { OcpiResponse } from '../model/ocpi.response';
+import { Service } from 'typedi';
+import { ChargingProfileResult } from "../model/ChargingProfileResult";
+
+@Service()
+export class ChargingProfilesClientApi extends BaseClientApi {
+  async postSetChargingProfileResult(
+    url: string,
+    body: ChargingProfileResult,
+  ): Promise<OcpiResponse<string> | null> {
+    return this.createRaw<OcpiResponse<string>>(url, body, {}).then(
+      (response) => response.result,
+    );
+  }
+}

--- a/00_Base/src/util/CommandExecutor.ts
+++ b/00_Base/src/util/CommandExecutor.ts
@@ -9,17 +9,17 @@ import {
   RequestStopTransactionRequest,
   ReserveNowRequest,
 } from '@citrineos/base';
-import {Service} from "typedi";
-import {ResponseUrlRepository} from "../repository/response-url.repository";
-import {v4 as uuidv4} from 'uuid';
-import {StopSession} from "../model/StopSession";
-import {NotFoundException} from "../exception/not.found.exception";
-import {ReserveNow} from "../model/ReserveNow";
-import {CancelReservation} from "../model/CancelReservation";
-import {OcpiEvseEntityRepository} from "../repository/ocpi-evse.repository";
-import {SequelizeTransactionEventRepository, SequelizeChargingProfileRepository} from "@citrineos/data";
-import {SetChargingProfile} from "../model/SetChargingProfile";
-import {BadRequestError} from "routing-controllers";
+import { Service } from "typedi";
+import { ResponseUrlRepository } from "../repository/response-url.repository";
+import { v4 as uuidv4 } from 'uuid';
+import { StopSession } from "../model/StopSession";
+import { NotFoundException } from "../exception/not.found.exception";
+import { ReserveNow } from "../model/ReserveNow";
+import { CancelReservation } from "../model/CancelReservation";
+import { OcpiEvseEntityRepository } from "../repository/ocpi-evse.repository";
+import { SequelizeTransactionEventRepository, SequelizeChargingProfileRepository } from "@citrineos/data";
+import { SetChargingProfile } from "../model/SetChargingProfile";
+import { BadRequestError } from "routing-controllers";
 import {
     ChargingProfileKindEnumType,
     ChargingProfilePurposeEnumType, ChargingProfileType,

--- a/00_Base/src/util/CommandExecutor.ts
+++ b/00_Base/src/util/CommandExecutor.ts
@@ -2,7 +2,6 @@ import { StartSession } from '../model/StartSession';
 import {
   AbstractModule,
   CallAction,
-  CancelReservationRequest,
   GetCompositeScheduleRequest,
   IdTokenEnumType,
   MessageOrigin,
@@ -10,15 +9,22 @@ import {
   RequestStopTransactionRequest,
   ReserveNowRequest,
 } from '@citrineos/base';
-import { Service } from 'typedi';
-import { ResponseUrlRepository } from '../repository/response-url.repository';
-import { v4 as uuidv4 } from 'uuid';
-import { StopSession } from '../model/StopSession';
-import { NotFoundException } from '../exception/not.found.exception';
-import { ReserveNow } from '../model/ReserveNow';
-import { CancelReservation } from '../model/CancelReservation';
-import { OcpiEvseEntityRepository } from '../repository/ocpi-evse.repository';
-import { SequelizeTransactionEventRepository } from '@citrineos/data';
+import {Service} from "typedi";
+import {ResponseUrlRepository} from "../repository/response-url.repository";
+import {v4 as uuidv4} from 'uuid';
+import {StopSession} from "../model/StopSession";
+import {NotFoundException} from "../exception/not.found.exception";
+import {ReserveNow} from "../model/ReserveNow";
+import {CancelReservation} from "../model/CancelReservation";
+import {OcpiEvseEntityRepository} from "../repository/ocpi-evse.repository";
+import {SequelizeTransactionEventRepository} from "@citrineos/data";
+import {SetChargingProfile} from "../model/SetChargingProfile";
+import {BadRequestError} from "routing-controllers";
+import {
+    ChargingProfileKindEnumType,
+    ChargingProfilePurposeEnumType, ChargingProfileType,
+    ChargingSchedulePeriodType, ChargingScheduleType, SetChargingProfileRequest
+} from "@citrineos/base";
 
 @Service()
 export class CommandExecutor {
@@ -155,14 +161,86 @@ export class CommandExecutor {
       evseId: transaction.evse?.id,
     } as GetCompositeScheduleRequest;
 
-    this.abstractModule.sendCall(
-      transaction.stationId,
-      'tenantId',
-      CallAction.GetCompositeSchedule,
-      request,
-      undefined,
-      correlationId,
-      MessageOrigin.CentralSystem,
-    );
-  }
+        this.abstractModule.sendCall(
+            transaction.stationId,
+            "tenantId",
+            CallAction.GetCompositeSchedule,
+            request,
+            undefined,
+            correlationId,
+            MessageOrigin.CentralSystem
+        );
+    }
+
+    public async executePutChargingProfile(sessionId: string, setChargingProfile: SetChargingProfile) {
+        // TODO: find station id by session id when session and location module is implemented
+        const stationId = "cp001";
+        const transaction = await this.transactionRepo.readTransactionByStationIdAndTransactionId(stationId,sessionId);
+
+        if (!transaction) {
+            throw new NotFoundException("Session not found");
+        }
+
+        console.log(`Found transaction: ${JSON.stringify(transaction)}`);
+
+        const evseId = transaction.evse?.id;
+
+        const correlationId = uuidv4();
+        await this.responseUrlRepo.saveResponseUrl(correlationId, setChargingProfile.response_url);
+
+        this.abstractModule.sendCall(
+            stationId,
+            "tenantId",
+            CallAction.SetChargingProfile,
+            this.mapSetChargingProfileRequest(setChargingProfile, evseId!, sessionId),
+            undefined,
+            correlationId,
+            MessageOrigin.CentralSystem
+        );
+    }
+
+    private mapSetChargingProfileRequest(setChargingProfile: SetChargingProfile, evseId: number, sessionId: string): SetChargingProfileRequest {
+        const startDateTime = setChargingProfile.charging_profile.start_date_time;
+        const duration = setChargingProfile.charging_profile.duration;
+        let endDateTime;
+        if (startDateTime && duration) {
+            endDateTime = startDateTime;
+            endDateTime.setSeconds(endDateTime.getSeconds() + duration);
+        }
+
+        // Charging profile periods are required in OCPP SetChargingProfileRequest
+        if (!setChargingProfile.charging_profile.charging_profile_period) {
+            throw new BadRequestError("Validation failed: Missing charging_profile_period");
+        }
+        const chargingProfilePeriods: ChargingSchedulePeriodType[] = [];
+        for (const chargingProfilePeriod of setChargingProfile.charging_profile.charging_profile_period) {
+            chargingProfilePeriods.push({
+                startPeriod: chargingProfilePeriod.start_period,
+                limit: chargingProfilePeriod.limit
+            });
+        }
+
+        const chargingSchedule = {
+            id: 1, // TODO: tbd
+            startSchedule: startDateTime?.toISOString(),
+            duration: duration,
+            chargingRateUnit: setChargingProfile.charging_profile.charging_rate_unit.toUpperCase(),
+            minChargingRate: setChargingProfile.charging_profile.min_charging_rate,
+            chargingSchedulePeriod: chargingProfilePeriods
+        } as ChargingScheduleType;
+
+        return {
+            evseId,
+            chargingProfile: {
+                id: 1, // TODO: tbd
+                stackLevel: 0,
+                chargingProfilePurpose: ChargingProfilePurposeEnumType.TxProfile,
+                chargingProfileKind: startDateTime ? ChargingProfileKindEnumType.Absolute : ChargingProfileKindEnumType.Relative,
+                validFrom: startDateTime?.toISOString(),
+                validTo:endDateTime?.toISOString(),
+                chargingSchedule: [chargingSchedule],
+                transactionId: sessionId
+            } as ChargingProfileType,
+        } as SetChargingProfileRequest;
+    }
 }

--- a/03_Modules/ChargingProfiles/package.json
+++ b/03_Modules/ChargingProfiles/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@citrineos/ocpi-base": "1.1.1",
-    "@citrineos/base": "1.2.3",
-    "@citrineos/util": "1.2.3",
+    "@citrineos/base": "1.3.0",
+    "@citrineos/util": "1.3.0",
     "deasync-promise": "^1.0.1",
     "tslog": "^4.9.2"
   }

--- a/03_Modules/ChargingProfiles/src/index.ts
+++ b/03_Modules/ChargingProfiles/src/index.ts
@@ -6,7 +6,7 @@
 import { ChargingProfilesModuleApi } from './module/api';
 import {
   CacheWrapper,
-  CommandsClientApi,
+  ChargingProfilesClientApi,
   OcpiModule,
   OcpiServerConfig,
   ResponseUrlRepository,
@@ -23,7 +23,7 @@ import { ILogObj, Logger } from 'tslog';
 
 import { Container, Service } from 'typedi';
 import { useContainer } from 'routing-controllers';
-import { SequelizeTransactionEventRepository } from '@citrineos/data';
+import { SequelizeChargingProfileRepository, SequelizeTransactionEventRepository } from '@citrineos/data';
 
 useContainer(Container);
 
@@ -40,6 +40,11 @@ export class ChargingProfilesModule implements OcpiModule {
       SequelizeTransactionEventRepository,
       new SequelizeTransactionEventRepository(config as SystemConfig, logger),
     );
+
+    Container.set(
+        SequelizeChargingProfileRepository,
+        new SequelizeChargingProfileRepository(config as SystemConfig, logger),
+    );
   }
 
   init(handler?: IMessageHandler, sender?: IMessageSender): void {
@@ -49,7 +54,7 @@ export class ChargingProfilesModule implements OcpiModule {
         this.config as SystemConfig,
         this.cache.cache,
         Container.get(ResponseUrlRepository),
-        Container.get(CommandsClientApi),
+        Container.get(ChargingProfilesClientApi),
         handler,
         sender,
         this.logger,

--- a/03_Modules/ChargingProfiles/src/module/api.ts
+++ b/03_Modules/ChargingProfiles/src/module/api.ts
@@ -5,17 +5,17 @@
 
 import { IChargingProfilesModuleApi } from './interface';
 
-import { Get, Param, QueryParam } from 'routing-controllers';
+import {Body, Get, Param, Put, QueryParam} from 'routing-controllers';
 
 import { HttpStatus } from '@citrineos/base';
 import {
-  AsOcpiFunctionalEndpoint,
-  BaseController,
-  generateMockOcpiResponse,
-  ModuleId,
-  ResponseSchema,
-  OcpiResponse,
-  ChargingProfilesService,
+    AsOcpiFunctionalEndpoint,
+    BaseController,
+    generateMockOcpiResponse,
+    ModuleId,
+    ResponseSchema,
+    OcpiResponse, ChargingProfilesService,
+    SetChargingProfile
 } from '@citrineos/ocpi-base';
 
 import { Service } from 'typedi';
@@ -34,24 +34,36 @@ export class ChargingProfilesModuleApi
     super();
   }
 
-  @Get('/:sessionId')
-  @AsOcpiFunctionalEndpoint()
-  @ResponseSchema(OcpiResponse<ChargingProfileResponse>, {
-    statusCode: HttpStatus.OK,
-    description: 'Successful response',
-    examples: {
-      success: generateMockOcpiResponse(OcpiResponse<ChargingProfileResponse>),
-    },
-  })
-  async getActiveChargingProfile(
-    @Param('sessionId') sessionId: string,
-    @QueryParam('duration') duration: number,
-    @QueryParam('response_url') responseUrl: string,
-  ): Promise<OcpiResponse<ChargingProfileResponse>> {
-    return this.service.getActiveChargingProfile(
-      sessionId,
-      duration,
-      responseUrl,
-    );
-  }
+    @Get('/:sessionId')
+    @AsOcpiFunctionalEndpoint()
+    @ResponseSchema(OcpiResponse<ChargingProfileResponse>, {
+        statusCode: HttpStatus.OK,
+        description: 'Successful response',
+        examples: {
+            success: generateMockOcpiResponse(OcpiResponse<ChargingProfileResponse>),
+        },
+    })
+    async getActiveChargingProfile(
+        @Param('sessionId') sessionId: string,
+        @QueryParam("duration") duration: number,
+        @QueryParam("response_url") responseUrl: string,
+    ): Promise<OcpiResponse<ChargingProfileResponse>> {
+        return this.service.getActiveChargingProfile(sessionId, duration, responseUrl);
+    }
+
+    @Put('/:sessionId')
+    @AsOcpiFunctionalEndpoint()
+    @ResponseSchema(OcpiResponse<ChargingProfileResponse>, {
+        statusCode: HttpStatus.OK,
+        description: 'Successful response',
+        examples: {
+            success: generateMockOcpiResponse(OcpiResponse<ChargingProfileResponse>),
+        },
+    })
+    async updateChargingProfile(
+        @Param('sessionId') sessionId: string,
+        @Body() payload: SetChargingProfile,
+    ): Promise<OcpiResponse<ChargingProfileResponse>> {
+        return this.service.putChargingProfile(sessionId, payload);
+    }
 }

--- a/03_Modules/ChargingProfiles/src/module/api.ts
+++ b/03_Modules/ChargingProfiles/src/module/api.ts
@@ -5,17 +5,18 @@
 
 import { IChargingProfilesModuleApi } from './interface';
 
-import {Body, Get, Param, Put, QueryParam} from 'routing-controllers';
+import { Body, Get, Param, Put, QueryParam } from 'routing-controllers';
 
 import { HttpStatus } from '@citrineos/base';
 import {
-    AsOcpiFunctionalEndpoint,
-    BaseController,
-    generateMockOcpiResponse,
-    ModuleId,
-    ResponseSchema,
-    OcpiResponse, ChargingProfilesService,
-    SetChargingProfile
+  AsOcpiFunctionalEndpoint,
+  BaseController,
+  generateMockOcpiResponse,
+  ModuleId,
+  ResponseSchema,
+  OcpiResponse,
+  ChargingProfilesService,
+  SetChargingProfile
 } from '@citrineos/ocpi-base';
 
 import { Service } from 'typedi';

--- a/03_Modules/Commands/package.json
+++ b/03_Modules/Commands/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@citrineos/ocpi-base": "1.1.1",
-    "@citrineos/base": "1.2.3",
-    "@citrineos/util": "1.2.3",
+    "@citrineos/base": "1.3.0",
+    "@citrineos/util": "1.3.0",
     "deasync-promise": "^1.0.1",
     "tslog": "^4.9.2"
   }

--- a/03_Modules/Versions/package.json
+++ b/03_Modules/Versions/package.json
@@ -26,9 +26,9 @@
   },
   "dependencies": {
     "@citrineos/ocpi-base": "1.1.1",
-    "@citrineos/base": "1.2.3",
-    "@citrineos/data": "1.2.3",
-    "@citrineos/util": "1.2.3",
+    "@citrineos/base": "1.3.0",
+    "@citrineos/data": "1.3.0",
+    "@citrineos/util": "1.3.0",
     "deasync-promise": "^1.0.1",
     "tslog": "^4.9.2"
   }


### PR DESCRIPTION
## Changes
Implement put charging profile endpoint defined in OCPI 2.2.1, 14.4.1.2. PUT Method
Changes in OCPP can be found here: https://github.com/citrineos/citrineos-core/commit/29cfe1226975e1f90728249bc1488ec7f09782bd
⚠️ We need to find a way to find out the station id and replace the mock data
⚠️ We need to run lint and fix the format

## Tests
1. Prepare a transaction in db <img width="887" alt="Screenshot 2024-06-21 at 1 53 10 PM" src="https://github.com/citrineos/citrineos-ocpi/assets/21100540/9d2f0c82-9d1a-4596-8662-5513bd0dd8a4">
2. Send put request <img width="1134" alt="Screenshot 2024-06-21 at 1 53 48 PM" src="https://github.com/citrineos/citrineos-ocpi/assets/21100540/78519012-2889-417b-b607-1afbc5876352">
3. Charger receives the call and send back a response  <img width="889" alt="Screenshot 2024-06-21 at 1 54 52 PM" src="https://github.com/citrineos/citrineos-ocpi/assets/21100540/06e35351-25bb-4d58-a4d1-8d3576a81a74">
4. The result is sent to the response url <img width="1228" alt="Screenshot 2024-06-21 at 1 56 35 PM" src="https://github.com/citrineos/citrineos-ocpi/assets/21100540/c4afd23c-14c5-4845-b2a2-f4c07c668f4b">
