### PR TITLE
fix: importing sequelize-typescript from core to prevent dependency conflicts

### DIFF
--- a/00_Base/src/model/BusinessDetails.ts
+++ b/00_Base/src/model/BusinessDetails.ts
@@ -9,7 +9,7 @@ import {
   HasOne,
   Model,
   Table,
-} from 'sequelize-typescript';
+} from '@citrineos/data';
 import { ClientCredentialsRole } from './ClientCredentialsRole';
 import { ServerCredentialsRole } from './ServerCredentialsRole';
 import { Exclude } from 'class-transformer';

--- a/00_Base/src/model/ClientCredentialsRole.ts
+++ b/00_Base/src/model/ClientCredentialsRole.ts
@@ -6,7 +6,7 @@ import {
   HasOne,
   Model,
   Table,
-} from 'sequelize-typescript';
+} from '@citrineos/data';
 import { Role } from './Role';
 import { ICredentialsRole } from './BaseCredentialsRole';
 import { IsNotEmpty, IsString, Length } from 'class-validator';

--- a/00_Base/src/model/ClientInformation.ts
+++ b/00_Base/src/model/ClientInformation.ts
@@ -6,7 +6,7 @@ import {
   HasMany,
   Model,
   Table,
-} from 'sequelize-typescript';
+} from '@citrineos/data';
 import { IsBoolean, IsNotEmpty, IsString } from 'class-validator';
 import {
   ClientCredentialsRole,

--- a/00_Base/src/model/ClientVersion.ts
+++ b/00_Base/src/model/ClientVersion.ts
@@ -6,7 +6,7 @@ import {
   HasMany,
   Model,
   Table,
-} from 'sequelize-typescript';
+} from '@citrineos/data';
 import { VersionNumber } from './VersionNumber';
 import { IsNotEmpty, IsString, IsUrl } from 'class-validator';
 import { Enum } from '../util/decorators/enum';

--- a/00_Base/src/model/CpoTenant.ts
+++ b/00_Base/src/model/CpoTenant.ts
@@ -1,4 +1,4 @@
-import { HasMany, Model, Table } from 'sequelize-typescript';
+import { HasMany, Model, Table } from '@citrineos/data';
 import { ClientInformation } from './ClientInformation';
 import { ServerCredentialsRole } from './ServerCredentialsRole';
 import { Exclude } from 'class-transformer';

--- a/00_Base/src/model/DTO/CredentialsDTO.ts
+++ b/00_Base/src/model/DTO/CredentialsDTO.ts
@@ -7,7 +7,7 @@ import {
   MaxLength,
   ValidateNested,
 } from 'class-validator';
-import { Index } from 'sequelize-typescript';
+import { Index } from '@citrineos/data';
 import { Type } from 'class-transformer';
 import { CredentialsRoleDTO } from './CredentialsRoleDTO';
 

--- a/00_Base/src/model/Endpoint.ts
+++ b/00_Base/src/model/Endpoint.ts
@@ -9,7 +9,7 @@ import {
   ForeignKey,
   Model,
   Table,
-} from 'sequelize-typescript';
+} from '@citrineos/data';
 import { OcpiNamespace } from '../util/ocpi.namespace';
 import { Exclude } from 'class-transformer';
 import { ClientVersion } from './ClientVersion';

--- a/00_Base/src/model/Image.ts
+++ b/00_Base/src/model/Image.ts
@@ -7,7 +7,7 @@ import {
   ForeignKey,
   Model,
   Table,
-} from 'sequelize-typescript';
+} from '@citrineos/data';
 import { Exclude } from 'class-transformer';
 import { BusinessDetails } from './BusinessDetails';
 import { ImageCategory } from './ImageCategory';

--- a/00_Base/src/model/ServerCredentialsRole.ts
+++ b/00_Base/src/model/ServerCredentialsRole.ts
@@ -6,7 +6,7 @@ import {
   HasOne,
   Model,
   Table,
-} from 'sequelize-typescript';
+} from '@citrineos/data';
 import { Role } from './Role';
 import { ICredentialsRole } from './BaseCredentialsRole';
 import { IsNotEmpty, IsString, Length } from 'class-validator';

--- a/00_Base/src/model/ServerVersion.ts
+++ b/00_Base/src/model/ServerVersion.ts
@@ -6,7 +6,7 @@ import {
   HasMany,
   Model,
   Table,
-} from 'sequelize-typescript';
+} from '@citrineos/data';
 import { VersionNumber } from './VersionNumber';
 import { IsNotEmpty, IsString, IsUrl } from 'class-validator';
 import { Enum } from '../util/decorators/enum';

--- a/00_Base/src/model/Version.ts
+++ b/00_Base/src/model/Version.ts
@@ -3,7 +3,7 @@ import { Endpoint } from './Endpoint';
 import { ClientInformation } from './ClientInformation';
 import { VersionDTO } from './DTO/VersionDTO';
 import { VersionDetailsDTO } from './DTO/VersionDetailsDTO';
-import { Column, DataType, HasMany, Model, Table } from 'sequelize-typescript';
+import { Column, DataType, HasMany, Model, Table } from '@citrineos/data';
 import { IsNotEmpty, IsString, IsUrl } from 'class-validator';
 import { Enum } from '../util/decorators/enum';
 import { VersionEndpoint } from './VersionEndpoint';

--- a/00_Base/src/model/VersionEndpoint.ts
+++ b/00_Base/src/model/VersionEndpoint.ts
@@ -10,7 +10,7 @@ import {
   ForeignKey,
   Model,
   Table,
-} from 'sequelize-typescript';
+} from '@citrineos/data';
 import { Endpoint, EndpointDTO } from './Endpoint';
 import { Version } from './Version';
 

--- a/00_Base/src/util/sequelize.ts
+++ b/00_Base/src/util/sequelize.ts
@@ -1,4 +1,4 @@
-import { Sequelize } from 'sequelize-typescript';
+import { Sequelize } from '@citrineos/data';
 import { ILogObj, Logger } from 'tslog';
 import { Dialect } from 'sequelize';
 import { OcpiServerConfig } from '../config/ocpi.server.config';


### PR DESCRIPTION
Adjusting all imports for sequelize-typescript related classes / methods to come from @citrineos/data