### PR TITLE
feat: add ocpi header decorator for easy access

### DIFF
--- a/00_Base/src/index.ts
+++ b/00_Base/src/index.ts
@@ -86,6 +86,7 @@ export { OcpiNamespace } from './util/ocpi.namespace';
 export { OcpiLogger } from './util/logger';
 export { OcpiSequelizeInstance } from './util/sequelize';
 export { AsOcpiRegistrationEndpoint } from './util/decorators/as.ocpi.registration.endpoint';
+export { OcpiHeaders } from './model/OcpiHeaders';
 export { AuthToken } from './util/decorators//auth.token';
 export { VersionNumberParam } from './util/decorators/version.number.param';
 export { EnumParam } from './util/decorators/enum.param';

--- a/00_Base/src/model/OcpiHeaders.ts
+++ b/00_Base/src/model/OcpiHeaders.ts
@@ -1,0 +1,30 @@
+import { IsNotEmpty, IsString, Length } from 'class-validator';
+
+export class OcpiHeaders {
+  @IsString()
+  @IsNotEmpty()
+  @Length(2)
+  fromCountryCode!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Length(3)
+  fromPartyId!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Length(2)
+  toCountryCode!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Length(3)
+  toPartyId!: string;
+
+  constructor(fromCountryCode: string, fromPartyId: string, toCountryCode: string, toPartyId: string) {
+    this.fromCountryCode = fromCountryCode;
+    this.fromPartyId = fromPartyId;
+    this.toCountryCode = toCountryCode;
+    this.toPartyId = toPartyId;
+  }
+}

--- a/00_Base/src/util/decorators/FunctionEndpointParams.ts
+++ b/00_Base/src/util/decorators/FunctionEndpointParams.ts
@@ -1,0 +1,19 @@
+import { OcpiHttpHeader } from '../ocpi.http.header';
+import { OcpiHeaders } from '../../model/OcpiHeaders';
+import { createParamDecorator } from 'routing-controllers';
+
+
+export function FunctionalEndpointParams() {
+  return createParamDecorator({
+    required: true,
+    value: (action: any) => {
+      const fromCountryCode = action.request.headers[OcpiHttpHeader.OcpiFromCountryCode.toLocaleLowerCase()];
+      const fromPartyId = action.request.headers[OcpiHttpHeader.OcpiFromPartyId.toLocaleLowerCase()];
+      const toCountryCode = action.request.headers[OcpiHttpHeader.OcpiToCountryCode.toLocaleLowerCase()];
+      const toPartyId = action.request.headers[OcpiHttpHeader.OcpiToPartyId.toLocaleLowerCase()];
+
+      const headers = new OcpiHeaders(fromCountryCode, fromPartyId, toCountryCode, toPartyId);
+      return headers;
+    },
+  });
+}


### PR DESCRIPTION
This adds a decorator to have easy access to the OCPI headers within the controllers. Sometimes these are needed for checking if the correct resources are accessed.