### PR TITLE
Fix Build Errors

### DIFF
--- a/00_Base/src/util/command.executor.ts
+++ b/00_Base/src/util/command.executor.ts
@@ -72,7 +72,7 @@ export class CommandExecutor {
       request,
       undefined,
       correlationId,
-      MessageOrigin.CentralSystem,
+      MessageOrigin.ChargingStationManagementSystem,
     );
   }
 
@@ -103,7 +103,7 @@ export class CommandExecutor {
       request,
       undefined,
       correlationId,
-      MessageOrigin.CentralSystem,
+      MessageOrigin.ChargingStationManagementSystem,
     );
   }
 
@@ -137,7 +137,7 @@ export class CommandExecutor {
       request,
       undefined,
       correlationId,
-      MessageOrigin.CentralSystem,
+      MessageOrigin.ChargingStationManagementSystem,
     );
   }
 
@@ -179,7 +179,7 @@ export class CommandExecutor {
       request,
       undefined,
       correlationId,
-      MessageOrigin.CentralSystem,
+      MessageOrigin.ChargingStationManagementSystem,
     );
   }
 
@@ -231,7 +231,7 @@ export class CommandExecutor {
       setChargingProfileRequest,
       undefined,
       correlationId,
-      MessageOrigin.CentralSystem,
+      MessageOrigin.ChargingStationManagementSystem,
     );
   }
 

--- a/03_Modules/Cdrs/package.json
+++ b/03_Modules/Cdrs/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@citrineos/ocpi-base": "1.1.1",
-    "@citrineos/base": "1.2.3",
-    "@citrineos/util": "1.2.3",
+    "@citrineos/base": "1.3.0",
+    "@citrineos/util": "1.3.0",
     "deasync-promise": "^1.0.1",
     "tslog": "^4.9.2"
   }

--- a/03_Modules/ChargingProfiles/src/module/handlers.ts
+++ b/03_Modules/ChargingProfiles/src/module/handlers.ts
@@ -171,7 +171,7 @@ export class ChargingProfilesOcppHandlers extends AbstractModule {
               } as GetCompositeScheduleRequest,
               undefined,
               uuidv4(),
-              MessageOrigin.CentralSystem,
+              MessageOrigin.ChargingStationManagementSystem,
             );
           }
         }
@@ -222,7 +222,7 @@ export class ChargingProfilesOcppHandlers extends AbstractModule {
               } as GetCompositeScheduleRequest,
               undefined,
               uuidv4(),
-              MessageOrigin.CentralSystem,
+              MessageOrigin.ChargingStationManagementSystem,
             );
           }
         }
@@ -260,7 +260,7 @@ export class ChargingProfilesOcppHandlers extends AbstractModule {
         } as GetCompositeScheduleRequest,
         undefined,
         uuidv4(),
-        MessageOrigin.CentralSystem,
+        MessageOrigin.ChargingStationManagementSystem,
       );
     }
   }
@@ -288,7 +288,7 @@ export class ChargingProfilesOcppHandlers extends AbstractModule {
           } as GetCompositeScheduleRequest,
           undefined,
           uuidv4(),
-          MessageOrigin.CentralSystem,
+          MessageOrigin.ChargingStationManagementSystem,
         );
       }
     }
@@ -335,7 +335,7 @@ export class ChargingProfilesOcppHandlers extends AbstractModule {
             } as GetCompositeScheduleRequest,
             undefined,
             uuidv4(),
-            MessageOrigin.CentralSystem,
+            MessageOrigin.ChargingStationManagementSystem,
           );
         }
       }

--- a/Server/package.json
+++ b/Server/package.json
@@ -45,6 +45,7 @@
     "@citrineos/ocpi-credentials": "1.1.1",
     "@citrineos/ocpi-locations": "1.3.0",
     "@citrineos/ocpi-versions": "1.1.1",
+    "@citrineos/ocpi-cdrs": "1.3.0",
     "@citrineos/ocpi-charging-profiles": "1.1.1",
     "@citrineos/ocpi-sessions": "1.3.0",
     "@citrineos/ocpi-tariffs": "1.1.1",

--- a/Server/src/index.ts
+++ b/Server/src/index.ts
@@ -18,6 +18,7 @@ import { CommandsModule } from '@citrineos/ocpi-commands';
 import { LocationsModule } from '@citrineos/ocpi-locations';
 import { VersionsModule } from '@citrineos/ocpi-versions';
 import { SessionsModule } from '@citrineos/ocpi-sessions';
+import { CdrsModule } from '@citrineos/ocpi-cdrs';
 import { CredentialsModule } from '@citrineos/ocpi-credentials';
 import { Container } from 'typedi';
 import { TariffsModule } from '@citrineos/ocpi-tariffs';
@@ -85,6 +86,11 @@ class CitrineOSServer {
       },
       {
         module: TariffsModule,
+        handler: this._createHandler(),
+        sender: this._createSender(),
+      },
+      {
+        module: CdrsModule,
         handler: this._createHandler(),
         sender: this._createSender(),
       },

--- a/Server/tsconfig.json
+++ b/Server/tsconfig.json
@@ -20,6 +20,9 @@
       "path": "../03_Modules/Versions"
     },
     {
+      "path": "../03_Modules/Cdrs"
+    },
+    {
       "path": "../03_Modules/Credentials"
     },
     {


### PR DESCRIPTION
This PR fixes build errors,
1. replace incorrect `MessageOrigin.CentralSystem` with `MessageOrigin.ChargingStationManagementSystem`
2. add missing configuration for CDR Module

There is another related PR in core project: [Fix Build Errors](https://github.com/citrineos/citrineos-core/pull/150)