### PR TITLE
fix: reverting paginated params date_from and date_to changes

### DIFF
--- a/00_Base/src/controllers/param/paginated.params.ts
+++ b/00_Base/src/controllers/param/paginated.params.ts
@@ -1,4 +1,4 @@
-import { IsDate, IsInt, Min } from 'class-validator';
+import { IsDateString, IsInt, Min } from 'class-validator';
 import { Optional } from '../../util/decorators/optional';
 import { DEFAULT_LIMIT, DEFAULT_OFFSET } from '../../model/PaginatedResponse';
 
@@ -13,27 +13,27 @@ export class PaginatedParams {
   @Optional()
   limit?: number = DEFAULT_LIMIT;
 
-  @IsDate()
+  @IsDateString()
   @Optional()
-  private _date_from?: Date;
+  private _date_from?: string;
 
-  @IsDate()
+  @IsDateString()
   @Optional()
-  private _date_to?: Date;
+  private _date_to?: string;
 
-  get date_from(): Date | undefined {
-    return this._date_from ? new Date(this._date_from) : undefined;
+  get date_from(): Date {
+    return new Date(this._date_from!);
   }
 
-  get date_to(): Date | undefined {
-    return this._date_to ? new Date(this._date_to) : undefined;
+  get date_to(): Date {
+    return new Date(this._date_to!);
   }
 
-  set date_from(value: string | Date | undefined) {
-    this._date_from = value ? new Date(value) : undefined;
+  set date_from(value: Date) {
+    this._date_from = value.toISOString();
   }
 
-  set date_to(value: string | Date | undefined) {
-    this._date_to = value ? new Date(value) : undefined;
+  set date_to(value: Date) {
+    this._date_to = value.toISOString();
   }
 }


### PR DESCRIPTION
fix: reverting paginated params date_from and date_to strings to be IsDateString typed as strings with getters and setters that convert them into Dates which does appear to be working properly

<img width="1594" alt="Screenshot 2024-07-09 at 10 53 01 AM" src="https://github.com/citrineos/citrineos-ocpi/assets/63012697/bd8934bf-e40a-41f9-a064-61798be16578">
<img width="2056" alt="Screenshot 2024-07-09 at 10 50 29 AM" src="https://github.com/citrineos/citrineos-ocpi/assets/63012697/70ce7ac5-8511-4f60-9586-735896f15f02">
