### PR TITLE
feature/enable-ocpi-validation-for-koa-server-responses

### DIFF
--- a/00_Base/src/broadcaster/cdr.broadcaster.ts
+++ b/00_Base/src/broadcaster/cdr.broadcaster.ts
@@ -1,5 +1,8 @@
 import { Service } from 'typedi';
-import { SequelizeTransactionEventRepository, Transaction, } from '@citrineos/data';
+import {
+  SequelizeTransactionEventRepository,
+  Transaction,
+} from '@citrineos/data';
 import { CredentialsService } from '../services/credentials.service';
 import { ILogObj, Logger } from 'tslog';
 import { BaseBroadcaster } from './BaseBroadcaster';

--- a/00_Base/src/exception/ResponseValidationError.ts
+++ b/00_Base/src/exception/ResponseValidationError.ts
@@ -1,0 +1,6 @@
+export class ResponseValidationError extends Error {
+  constructor(message: string) {
+    super(`Response validation error message: "${message}"`);
+    this.name = 'ResponseValidationError';
+  }
+}

--- a/00_Base/src/index.ts
+++ b/00_Base/src/index.ts
@@ -26,9 +26,11 @@ import {
   SequelizeTransactionEventRepository,
   SequelizeVariableMonitoringRepository,
 } from '@citrineos/data';
+
 import { SessionBroadcaster } from './broadcaster/session.broadcaster';
 import { CdrBroadcaster } from './broadcaster/cdr.broadcaster';
 
+export { ValidatedResponseSchema } from './util/decorators/ValidatedResponseSchema';
 export { NotFoundException } from './exception/NotFoundException';
 export { FunctionalEndpointParams } from './util/decorators/FunctionEndpointParams';
 export { PaginatedOcpiParams } from './trigger/param/paginated.ocpi.params';
@@ -40,7 +42,7 @@ export { PaginatedSessionResponse } from './model/Session';
 export { Role } from './model/Role';
 export { ImageCategory } from './model/ImageCategory';
 export { ImageType } from './model/ImageType';
-export { CountryCode } from './util/util';
+export * from './util/util';
 export { KoaServer } from './util/koa.server';
 export { InterfaceRole } from './model/InterfaceRole';
 export { toCredentialsDTO } from './model/ClientInformation';
@@ -203,6 +205,8 @@ export class OcpiModuleConfig {
   sender?: IMessageSender;
 }
 
+export const OcpiRoutePrefix = '/ocpi';
+
 export class OcpiServer extends KoaServer {
   koa!: Koa;
   readonly serverConfig: OcpiServerConfig;
@@ -248,9 +252,10 @@ export class OcpiServer extends KoaServer {
           CdrsController,
           ChargingProfilesController,
         ],
-        routePrefix: '/ocpi',
+        routePrefix: OcpiRoutePrefix,
         middlewares: [GlobalExceptionHandler, LoggingMiddleware],
         defaultErrorHandler: false,
+        validation: true,
       } as RoutingControllersOptions;
       this.initApp(options);
       this.initKoaSwagger(
@@ -260,7 +265,7 @@ export class OcpiServer extends KoaServer {
         },
         [
           {
-            url: '/ocpi',
+            url: OcpiRoutePrefix,
           },
         ],
       );

--- a/00_Base/src/mapper/OcpiTokensMapper.ts
+++ b/00_Base/src/mapper/OcpiTokensMapper.ts
@@ -6,13 +6,16 @@ import {
   IdTokenInfoType,
   IdTokenType,
 } from '@citrineos/base';
-import {OcpiToken} from '../model/OcpiToken';
-import {TokenType} from '../model/TokenType';
-import {Authorization, IdToken} from '@citrineos/data';
-import {TokenDTO} from '../model/DTO/TokenDTO';
+import { OcpiToken } from '../model/OcpiToken';
+import { TokenType } from '../model/TokenType';
+import { Authorization, IdToken } from '@citrineos/data';
+import { TokenDTO } from '../model/DTO/TokenDTO';
 
 export class OcpiTokensMapper {
-  public static toEntity(authorizationId: number, tokenDto: TokenDTO): OcpiToken {
+  public static toEntity(
+    authorizationId: number,
+    tokenDto: TokenDTO,
+  ): OcpiToken {
     return OcpiToken.build({
       authorization_id: authorizationId,
       country_code: tokenDto.country_code,
@@ -101,7 +104,9 @@ export class OcpiTokensMapper {
     return { idToken, idTokenInfo };
   }
 
-  public static async getContractId(authorization: Authorization): Promise<string> {
+  public static async getContractId(
+    authorization: Authorization,
+  ): Promise<string> {
     const idToken = await authorization.$get('idToken');
     const additionalInfo = await (idToken! as IdToken).$get('additionalInfo');
 

--- a/00_Base/src/mapper/cdr.mapper.ts
+++ b/00_Base/src/mapper/cdr.mapper.ts
@@ -1,7 +1,12 @@
 import { Service } from 'typedi';
 import { Cdr } from '../model/Cdr';
 import { Session } from '../model/Session';
-import { SequelizeLocationRepository, SequelizeTariffRepository, Tariff, Transaction, } from '@citrineos/data';
+import {
+  SequelizeLocationRepository,
+  SequelizeTariffRepository,
+  Tariff,
+  Transaction,
+} from '@citrineos/data';
 import { TariffKey } from '../model/OcpiTariff';
 import { SessionMapper } from './session.mapper';
 import { OcpiLogger } from '../util/logger';
@@ -21,8 +26,7 @@ export class CdrMapper {
     readonly locationRepository: SequelizeLocationRepository,
     readonly tariffRepository: SequelizeTariffRepository,
     readonly tariffsService: TariffsService,
-  ) {
-  }
+  ) {}
 
   public async mapTransactionsToCdrs(
     transactions: Transaction[],
@@ -57,7 +61,7 @@ export class CdrMapper {
         transactionIdToOcpiTariffMap,
       );
     } catch (error) {
-      // TODO: Handle Error 
+      // TODO: Handle Error
       throw new Error();
     }
   }
@@ -87,18 +91,21 @@ export class CdrMapper {
   ): Promise<Map<string, OcpiTariff>> {
     const transactionIdToOcpiTariffMap = new Map<string, OcpiTariff>();
     await Promise.all(
-      sessions.filter(session => transactionIdToTariffMap.get(session.id)).map(async (session) => {
-        const tariffKey = {
-          id: String(transactionIdToTariffMap.get(session.id)?.id),
-          // TODO: Ensure CPO Country Code, Party ID exists for the tariff in question
-          countryCode: cpoCountryCode || 'US',
-          partyId: cpoPartyId || 'CPO',
-        } as TariffKey;
-        const tariff = await this.tariffsService.getTariffByCoreKey(tariffKey);
-        if (tariff) {
-          transactionIdToOcpiTariffMap.set(session.id, tariff);
-        }
-      }),
+      sessions
+        .filter((session) => transactionIdToTariffMap.get(session.id))
+        .map(async (session) => {
+          const tariffKey = {
+            id: String(transactionIdToTariffMap.get(session.id)?.id),
+            // TODO: Ensure CPO Country Code, Party ID exists for the tariff in question
+            countryCode: cpoCountryCode || 'US',
+            partyId: cpoPartyId || 'CPO',
+          } as TariffKey;
+          const tariff =
+            await this.tariffsService.getTariffByCoreKey(tariffKey);
+          if (tariff) {
+            transactionIdToOcpiTariffMap.set(session.id, tariff);
+          }
+        }),
     );
     return transactionIdToOcpiTariffMap;
   }
@@ -377,8 +384,8 @@ export class CdrMapper {
   private getStartAndEndEvents(
     transaction: Transaction,
   ): [
-      TransactionEventRequest | undefined,
-      TransactionEventRequest | undefined,
+    TransactionEventRequest | undefined,
+    TransactionEventRequest | undefined,
   ] {
     const startEvent = transaction.transactionEvents?.find(
       (event) => event.eventType === 'Started',

--- a/00_Base/src/mapper/session.mapper.ts
+++ b/00_Base/src/mapper/session.mapper.ts
@@ -1,11 +1,15 @@
 import { Service } from 'typedi';
 import { Session } from '../model/Session';
-import { MeasurandEnumType, MeterValueType, TransactionEventEnumType, TransactionEventRequest } from '@citrineos/base';
+import {
+  MeasurandEnumType,
+  MeterValueType,
+  TransactionEventEnumType,
+  TransactionEventRequest,
+} from '@citrineos/base';
 import { Transaction, TransactionEvent } from '@citrineos/data';
 import { AuthMethod } from '../model/AuthMethod';
 import { ChargingPeriod } from '../model/ChargingPeriod';
 import { CdrDimensionType } from '../model/CdrDimensionType';
-import { SingleTokenRequest } from '../model/OcpiToken';
 import { OcpiLocation, OcpiLocationProps } from '../model/OcpiLocation';
 import { CdrToken } from '../model/CdrToken';
 import { SessionStatus } from '../model/SessionStatus';
@@ -39,14 +43,11 @@ export class SessionMapper {
           toCountryCode,
           toPartyId,
         ),
-        this.getTokensForTransactions(
-          transactions,
-        ),
+        this.getTokensForTransactions(transactions),
       ]);
     return transactions
       .filter(
-        (transaction) =>
-          transactionIdToLocationMap[transaction.id] // todo skipping check for token for now
+        (transaction) => transactionIdToLocationMap[transaction.id], // todo skipping check for token for now
       )
       .map((transaction) => {
         const location = transactionIdToLocationMap[transaction.id]!;
@@ -233,7 +234,7 @@ export class SessionMapper {
       meterValue?.sampledValue.find(
         (sampledValue) =>
           sampledValue.measurand ===
-          MeasurandEnumType.Energy_Active_Import_Register &&
+            MeasurandEnumType.Energy_Active_Import_Register &&
           !sampledValue.phase,
       )?.value ?? undefined
     );
@@ -246,7 +247,7 @@ export class SessionMapper {
   ): number {
     const timeDiffMs = previousMeterValue
       ? new Date(meterValue.timestamp).getTime() -
-      new Date(previousMeterValue.timestamp).getTime()
+        new Date(previousMeterValue.timestamp).getTime()
       : new Date(meterValue.timestamp).getTime() - transactionStart.getTime();
 
     // Convert milliseconds to hours
@@ -299,13 +300,14 @@ export class SessionMapper {
         transaction.transactionEvents &&
         transaction.transactionEvents.length > 0
       ) {
-        const idToken = transaction.transactionEvents
-          .find(transaction => transaction.idToken)?.idToken;
+        const idToken = transaction.transactionEvents.find(
+          (t) => t.idToken,
+        )?.idToken;
 
         if (idToken?.idToken) {
           const tokenDto = await this.tokensRepository.getTokenDtoByIdToken(
             idToken.idToken,
-            idToken.type
+            idToken.type,
           );
 
           if (tokenDto) {

--- a/00_Base/src/model/OcpiTariff.ts
+++ b/00_Base/src/model/OcpiTariff.ts
@@ -1,11 +1,4 @@
-import {
-  Column,
-  DataType,
-  Index,
-  Model,
-  PrimaryKey,
-  Table,
-} from '@citrineos/data';
+import { Column, DataType, Index, Model, Table } from '@citrineos/data';
 import { CreationOptional } from 'sequelize';
 import { DisplayText } from './DisplayText';
 

--- a/00_Base/src/model/OcpiToken.ts
+++ b/00_Base/src/model/OcpiToken.ts
@@ -1,6 +1,5 @@
 import {
   IsArray,
-  IsBoolean,
   IsDate,
   IsNotEmpty,
   IsObject,
@@ -17,12 +16,7 @@ import { Optional } from '../util/decorators/optional';
 import { Enum } from '../util/decorators/enum';
 import { OcpiResponse, OcpiResponseStatusCode } from './ocpi.response';
 import { PaginatedResponse } from './PaginatedResponse';
-import {
-  Column,
-  DataType,
-  Model,
-  Table,
-} from 'sequelize-typescript';
+import { Column, DataType, Model, Table } from 'sequelize-typescript';
 import { TokenType } from './TokenType';
 import { TokenDTO } from './DTO/TokenDTO';
 
@@ -30,9 +24,9 @@ import { TokenDTO } from './DTO/TokenDTO';
 export class OcpiToken extends Model {
   @Column({
     type: DataType.INTEGER,
-    unique: true
+    unique: true,
   })
-  authorization_id!: number
+  authorization_id!: number;
 
   @Column(DataType.STRING)
   @MaxLength(2)

--- a/00_Base/src/model/PaginatedResponse.ts
+++ b/00_Base/src/model/PaginatedResponse.ts
@@ -1,28 +1,42 @@
 import { OcpiResponse, OcpiResponseStatusCode } from './ocpi.response';
-import { IsInt, IsNotEmpty, IsString, Max, Min } from 'class-validator';
+import {
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsUrl,
+  Max,
+  Min,
+} from 'class-validator';
 
 export const DEFAULT_LIMIT = 10;
 export const DEFAULT_OFFSET = 0;
 
+export enum PaginatedResponseProps {
+  total = 'total',
+  limit = 'limit',
+  offset = 'offset',
+  link = 'link',
+}
+
 export class PaginatedResponse<T> extends OcpiResponse<T[]> {
   @IsInt()
   @IsNotEmpty()
-  total?: number;
+  [PaginatedResponseProps.total]!: number;
 
   @IsInt()
   @IsNotEmpty()
   @Min(0)
-  offset?: number = DEFAULT_OFFSET;
+  [PaginatedResponseProps.offset]?: number = DEFAULT_OFFSET;
 
   @IsInt()
   @IsNotEmpty()
   @Min(0)
   @Max(200) // todo should this setting be in a config??
-  limit?: number = DEFAULT_LIMIT;
+  [PaginatedResponseProps.limit]?: number = DEFAULT_LIMIT;
 
-  @IsString()
-  @IsNotEmpty()
-  link?: string;
+  @IsUrl({ require_tld: false })
+  @IsOptional()
+  [PaginatedResponseProps.link]?: string;
 }
 
 export const buildOcpiPaginatedResponse = <T>(

--- a/00_Base/src/model/ServerCredentialsRole.ts
+++ b/00_Base/src/model/ServerCredentialsRole.ts
@@ -1,4 +1,12 @@
-import { BelongsTo, Column, DataType, ForeignKey, HasOne, Model, Table } from '@citrineos/data';
+import {
+  BelongsTo,
+  Column,
+  DataType,
+  ForeignKey,
+  HasOne,
+  Model,
+  Table,
+} from '@citrineos/data';
 import { Role } from './Role';
 import { ICredentialsRole } from './BaseCredentialsRole';
 import { IsNotEmpty, IsString, Length } from 'class-validator';
@@ -20,7 +28,10 @@ export enum ServerCredentialsRoleProps {
   indexes: [
     {
       unique: true,
-      fields: [ServerCredentialsRoleProps.countryCode, ServerCredentialsRoleProps.partyId],
+      fields: [
+        ServerCredentialsRoleProps.countryCode,
+        ServerCredentialsRoleProps.partyId,
+      ],
     },
   ],
 })

--- a/00_Base/src/model/ocpi.response.ts
+++ b/00_Base/src/model/ocpi.response.ts
@@ -19,10 +19,17 @@ export enum OcpiResponseStatusCode {
   HubConnectionProblem = 4003,
 }
 
+export enum OcpiResponseProps {
+  status_code = 'status_code',
+  status_message = 'status_message',
+  timestamp = 'timestamp',
+  data = 'data',
+}
+
 export class OcpiResponse<T> {
   @Enum(OcpiResponseStatusCode, 'OcpiResponseStatusCode')
   @IsNotEmpty()
-  status_code!: OcpiResponseStatusCode;
+  [OcpiResponseProps.status_code]!: OcpiResponseStatusCode;
   /**
    *
    * @type {string}
@@ -30,7 +37,7 @@ export class OcpiResponse<T> {
    */
   @IsString()
   @Optional()
-  status_message?: string;
+  [OcpiResponseProps.status_message]?: string;
 
   /**
    *
@@ -38,15 +45,14 @@ export class OcpiResponse<T> {
    * @memberof OcpiResponseDTO
    */
   @IsDate()
-  timestamp!: Date;
+  [OcpiResponseProps.timestamp]!: Date;
 
   /**
    *
    * @type {object}
    * @memberof OcpiResponseDTO
    */
-  @Optional()
-  data?: T;
+  [OcpiResponseProps.data]?: T;
 }
 
 export const buildOcpiResponse = <T>(

--- a/00_Base/src/util/command.executor.ts
+++ b/00_Base/src/util/command.executor.ts
@@ -59,7 +59,9 @@ export class CommandExecutor {
       remoteStartId: responseUrlEntity.id,
       idToken: {
         idToken: startSession.token.uid,
-        type: OcpiTokensMapper.mapOcpiTokenTypeToOcppIdTokenType(startSession.token.type),
+        type: OcpiTokensMapper.mapOcpiTokenTypeToOcppIdTokenType(
+          startSession.token.type,
+        ),
       },
       evseId: evse.evseId,
     } as RequestStartTransactionRequest;

--- a/00_Base/src/util/decorators/ValidatedResponseSchema.ts
+++ b/00_Base/src/util/decorators/ValidatedResponseSchema.ts
@@ -10,6 +10,15 @@ import { ResponseValidationMiddleware } from '../middleware/ResponseValidationMi
 
 export const validatedResponseParam = 'validatedResponseParam';
 
+/**
+ * ValidatedResponseSchema decorator wraps {@link ResponseSchema} and adds the input
+ * responseClass into Reflect.metadata and enables the {@link ResponseValidationMiddleware}
+ * which will get the responseClass via Reflect and perform class-validator validation
+ * on the response body prior to sending it back to the client.
+ * @param responseClass - response class
+ * @param options - {@link ResponseSchema} options
+ * @constructor
+ */
 export const ValidatedResponseSchema = (
   responseClass: Constructable<any>,
   options: {

--- a/00_Base/src/util/decorators/ValidatedResponseSchema.ts
+++ b/00_Base/src/util/decorators/ValidatedResponseSchema.ts
@@ -28,8 +28,8 @@ export const ValidatedResponseSchema = (
     isArray?: boolean;
     examples?: any;
   } = {},
-) => {
-  return function (object: any, methodName: string) {
+) =>
+  function (object: any, methodName: string) {
     // reuse original
     ResponseSchema(responseClass, options)(
       object as any,
@@ -48,4 +48,3 @@ export const ValidatedResponseSchema = (
     // apply middleware
     UseAfter(ResponseValidationMiddleware)(object, methodName);
   };
-};

--- a/00_Base/src/util/decorators/ValidatedResponseSchema.ts
+++ b/00_Base/src/util/decorators/ValidatedResponseSchema.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2023 S44, LLC
+// Copyright Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache 2.0
+
+import { Constructable } from 'typedi';
+import { ResponseSchema } from '../../openapi-spec-helper';
+import { UseAfter } from 'routing-controllers';
+import { ResponseValidationMiddleware } from '../middleware/ResponseValidationMiddleware';
+
+export const validatedResponseParam = 'validatedResponseParam';
+
+export const ValidatedResponseSchema = (
+  responseClass: Constructable<any>,
+  options: {
+    contentType?: string;
+    description?: string;
+    statusCode?: string | number;
+    isArray?: boolean;
+    examples?: any;
+  } = {},
+) => {
+  return function (object: any, methodName: string) {
+    // reuse original
+    ResponseSchema(responseClass, options)(
+      object as any,
+      methodName as any,
+      {} as any,
+    );
+
+    // Add custom metadata for additional use cases
+    Reflect.defineMetadata(
+      validatedResponseParam,
+      responseClass,
+      object,
+      methodName,
+    );
+
+    // apply middleware
+    UseAfter(ResponseValidationMiddleware)(object, methodName);
+  };
+};

--- a/00_Base/src/util/decorators/optional.ts
+++ b/00_Base/src/util/decorators/optional.ts
@@ -8,8 +8,10 @@ export const OPTIONAL_PARAM = 'isOptional';
  */
 export const Optional = (isOptional = true) =>
   function (object: NonNullable<unknown>, propertyName: string) {
-    // Apply the standard @IsOptional() decorator
-    IsOptional()(object, propertyName);
+    if (isOptional) {
+      // Apply the standard @IsOptional() decorator
+      IsOptional()(object, propertyName);
+    }
 
     // Add custom metadata for additional use cases
     Reflect.defineMetadata(OPTIONAL_PARAM, isOptional, object, propertyName);

--- a/00_Base/src/util/middleware/ResponseValidationMiddleware.ts
+++ b/00_Base/src/util/middleware/ResponseValidationMiddleware.ts
@@ -24,11 +24,7 @@ import { ResponseValidationError } from '../../exception/ResponseValidationError
 @Middleware({ type: 'before' })
 @Service()
 export class ResponseValidationMiddleware implements KoaMiddlewareInterface {
-  async use(
-    context: Context,
-    next: (err?: any) => Promise<any>,
-    ...args: any[]
-  ): Promise<any> {
+  async use(context: Context, next: (err?: any) => Promise<any>): Promise<any> {
     await next();
 
     const route = this.findRoute(context);
@@ -67,14 +63,20 @@ export class ResponseValidationMiddleware implements KoaMiddlewareInterface {
   private findRoute = (ctx: Context) => {
     const storage = getMetadataArgsStorage();
     const matchedRoute = ctx._matchedRoute;
-    if (!matchedRoute) return null;
+    if (!matchedRoute) {
+      return null;
+    }
     const method = ctx.request?.req?.method?.toLowerCase();
-    if (!method) return null;
-    const controllerMetadata = storage.controllers.find((controller) => {
-      return matchedRoute.startsWith(`${OcpiRoutePrefix}${controller.route}`);
-    });
+    if (!method) {
+      return null;
+    }
+    const controllerMetadata = storage.controllers.find((controller) =>
+      matchedRoute.startsWith(`${OcpiRoutePrefix}${controller.route}`),
+    );
 
-    if (!controllerMetadata) return null;
+    if (!controllerMetadata) {
+      return null;
+    }
 
     const actionMetadata = storage.actions.find((action) => {
       if (

--- a/00_Base/src/util/middleware/ResponseValidationMiddleware.ts
+++ b/00_Base/src/util/middleware/ResponseValidationMiddleware.ts
@@ -16,6 +16,11 @@ import {
 } from '../../index';
 import { ResponseValidationError } from '../../exception/ResponseValidationError';
 
+/**
+ * ResponseValidationMiddleware will perform class-validator validation on response body
+ * using the class that was passed into the {@link ValidatedResponseSchema} decorator
+ * which in turn enables the middleware on the endpoint
+ */
 @Middleware({ type: 'before' })
 @Service()
 export class ResponseValidationMiddleware implements KoaMiddlewareInterface {

--- a/00_Base/src/util/middleware/ResponseValidationMiddleware.ts
+++ b/00_Base/src/util/middleware/ResponseValidationMiddleware.ts
@@ -1,0 +1,90 @@
+import {
+  getMetadataArgsStorage,
+  InternalServerError,
+  KoaMiddlewareInterface,
+  Middleware,
+} from 'routing-controllers';
+import { plainToClass } from '../util';
+import { Service } from 'typedi';
+import { Context } from 'vm';
+import { validate } from 'class-validator';
+import { validatedResponseParam } from '../decorators/ValidatedResponseSchema';
+import {
+  OcpiResponse,
+  OcpiResponseStatusCode,
+  OcpiRoutePrefix,
+} from '../../index';
+import { ResponseValidationError } from '../../exception/ResponseValidationError';
+
+@Middleware({ type: 'before' })
+@Service()
+export class ResponseValidationMiddleware implements KoaMiddlewareInterface {
+  async use(
+    context: Context,
+    next: (err?: any) => Promise<any>,
+    ...args: any[]
+  ): Promise<any> {
+    await next();
+
+    const route = this.findRoute(context);
+    if (route) {
+      const { target, method } = route;
+      const responseClass = Reflect.getMetadata(
+        validatedResponseParam,
+        target.prototype,
+        method,
+      );
+
+      if (responseClass && context.body) {
+        const dto: OcpiResponse<any> = plainToClass(
+          responseClass,
+          context.body,
+        );
+        if (dto.status_code === OcpiResponseStatusCode.GenericSuccessCode) {
+          const errors = await validate(dto);
+          if (errors.length > 0) {
+            const errorMessages = errors
+              .map((error) => error.toString())
+              .join('');
+            throw new ResponseValidationError(errorMessages);
+          }
+        } else {
+          // todo handle OcpiErrorResponse and OcpiEmptyResponse
+        }
+      }
+    } else {
+      throw new InternalServerError(
+        'Could not find matching route? This should not happen',
+      );
+    }
+  }
+
+  private findRoute = (ctx: Context) => {
+    const storage = getMetadataArgsStorage();
+    const matchedRoute = ctx._matchedRoute;
+    if (!matchedRoute) return null;
+    const method = ctx.request?.req?.method?.toLowerCase();
+    if (!method) return null;
+    const controllerMetadata = storage.controllers.find((controller) => {
+      return matchedRoute.startsWith(`${OcpiRoutePrefix}${controller.route}`);
+    });
+
+    if (!controllerMetadata) return null;
+
+    const actionMetadata = storage.actions.find((action) => {
+      if (
+        action.target === controllerMetadata.target &&
+        action.type === method
+      ) {
+        let actionRoute = `${OcpiRoutePrefix}${controllerMetadata.route}`;
+        if (action.route) {
+          actionRoute += `${action.route}`;
+        }
+        return actionRoute === matchedRoute;
+      }
+      return false;
+    });
+
+    return actionMetadata || null;
+  };
+}

--- a/00_Base/src/util/middleware/ResponseValidationMiddleware.ts
+++ b/00_Base/src/util/middleware/ResponseValidationMiddleware.ts
@@ -59,7 +59,7 @@ export class ResponseValidationMiddleware implements KoaMiddlewareInterface {
       }
     } else {
       throw new InternalServerError(
-        'Could not find matching route? This should not happen',
+        'Could not find matching route. This should not happen.',
       );
     }
   }

--- a/00_Base/src/util/middleware/global.exception.handler.ts
+++ b/00_Base/src/util/middleware/global.exception.handler.ts
@@ -16,6 +16,7 @@ import { MissingParamException } from '../../exception/missing.param.exception';
 import { AlreadyRegisteredException } from '../../exception/AlreadyRegisteredException';
 import { NotRegisteredException } from '../../exception/NotRegisteredException';
 import { UnsuccessfulRequestException } from '../../exception/UnsuccessfulRequestException';
+import { ResponseValidationError } from '../../exception/ResponseValidationError';
 
 /**
  * GlobalExceptionHandler handles all exceptions
@@ -102,6 +103,15 @@ export class GlobalExceptionHandler implements KoaMiddlewareInterface {
             break;
           case UnsuccessfulRequestException.name:
             context.status = HttpStatus.OK;
+            context.body = JSON.stringify(
+              buildOcpiErrorResponse(
+                OcpiResponseStatusCode.ServerGenericError,
+                (err as any).message,
+              ),
+            );
+            break;
+          case ResponseValidationError.name:
+            context.status = HttpStatus.BAD_REQUEST;
             context.body = JSON.stringify(
               buildOcpiErrorResponse(
                 OcpiResponseStatusCode.ServerGenericError,

--- a/00_Base/src/util/middleware/paginated.middleware.ts
+++ b/00_Base/src/util/middleware/paginated.middleware.ts
@@ -6,8 +6,10 @@ import {
   DEFAULT_LIMIT,
   DEFAULT_OFFSET,
   PaginatedResponse,
+  PaginatedResponseProps,
 } from '../../model/PaginatedResponse';
 import { OcpiHttpHeader } from '../ocpi.http.header';
+import { deleteProperty } from '../util';
 
 /**
  * PaginatedMiddleware will handle pulling limit, offset and total out of the {@link PaginatedResponse} and ensuring
@@ -29,9 +31,9 @@ export class PaginatedMiddleware
     }
     context.response.set(OcpiHttpHeader.XTotalCount, paginatedResponse.total);
     context.response.set(OcpiHttpHeader.XLimit, paginatedResponse.limit);
-    delete paginatedResponse.limit;
-    delete paginatedResponse.offset;
-    delete paginatedResponse.total;
+    deleteProperty(paginatedResponse, PaginatedResponseProps.limit);
+    deleteProperty(paginatedResponse, PaginatedResponseProps.offset);
+    deleteProperty(paginatedResponse, PaginatedResponseProps.total);
   }
 
   private createLink(

--- a/00_Base/src/util/util.ts
+++ b/00_Base/src/util/util.ts
@@ -15,12 +15,14 @@ export enum CountryCode {
 }
 
 export const plainToClass = <T>(constructor: Constructable<T>, plain: T): T =>
-  plainToInstance(constructor, plain as T, {
-    excludeExtraneousValues: true,
-  });
+  plainToInstance(constructor, plain as T);
 
 export const base64Encode = (input: string): string =>
   Buffer.from(input).toString('base64');
 
 export const base64Decode = (input: string): string =>
   Buffer.from(input, 'base64').toString('utf-8');
+
+export const deleteProperty = <T>(obj: T, key: keyof T) => {
+  delete (obj as any)[key];
+};

--- a/03_Modules/Tariffs/src/module/api.ts
+++ b/03_Modules/Tariffs/src/module/api.ts
@@ -11,6 +11,7 @@ import { HttpStatus } from '@citrineos/base';
 import {
   AsOcpiFunctionalEndpoint,
   BaseController,
+  buildOcpiPaginatedResponse,
   FunctionalEndpointParams,
   generateMockOcpiResponse,
   ModuleId,
@@ -66,14 +67,13 @@ export class TariffsModuleApi
       paginationParams,
     );
 
-    return {
-      data: data,
-      total: count,
-      offset: paginationParams?.offset,
-      limit: paginationParams?.limit,
-      status_code: OcpiResponseStatusCode.GenericSuccessCode,
-      timestamp: new Date(),
-    };
+    return buildOcpiPaginatedResponse(
+      OcpiResponseStatusCode.GenericSuccessCode,
+      count,
+      paginationParams?.limit!,
+      paginationParams?.offset!,
+      data,
+    ) as PaginatedTariffResponse;
   }
 
   // TODO: auth & reorganize

--- a/03_Modules/Tariffs/src/module/api.ts
+++ b/03_Modules/Tariffs/src/module/api.ts
@@ -70,8 +70,8 @@ export class TariffsModuleApi
     return buildOcpiPaginatedResponse(
       OcpiResponseStatusCode.GenericSuccessCode,
       count,
-      paginationParams?.limit!,
-      paginationParams?.offset!,
+      paginationParams!.limit!,
+      paginationParams!.offset!,
       data,
     ) as PaginatedTariffResponse;
   }

--- a/03_Modules/Tokens/src/module/api.ts
+++ b/03_Modules/Tokens/src/module/api.ts
@@ -43,7 +43,6 @@ import {
   WrongClientAccessException,
 } from '@citrineos/ocpi-base';
 import { ITokensModuleApi } from './interface';
-import { plainToInstance } from 'class-transformer';
 
 @JsonController(`/:${versionIdParam}/${ModuleId.Tokens}`)
 @Service()

--- a/mock-client/tokens.ts
+++ b/mock-client/tokens.ts
@@ -32,7 +32,7 @@ export class TokensController extends BaseController {
     },
   })
   async getTokens(
-    @Paginated() paginationParams?: PaginatedParams,
+    @Paginated() _paginationParams?: PaginatedParams,
   ): Promise<PaginatedTokenResponse> {
     const response = buildOcpiPaginatedResponse(
       OcpiResponseStatusCode.GenericSuccessCode,

--- a/seeders/20240619140739-base-tokens.ts
+++ b/seeders/20240619140739-base-tokens.ts
@@ -50,10 +50,10 @@ module.exports = {
       createdAt: new Date(),
       updatedAt: new Date(),
     };
-    const ocppAuth1 = OcpiTokensMapper.mapOcpiTokenToOcppAuthorization(
+    const _ocppAuth1 = OcpiTokensMapper.mapOcpiTokenToOcppAuthorization(
       token1 as TokenDTO,
     );
-    const ocppAuth2 = OcpiTokensMapper.mapOcpiTokenToOcppAuthorization(
+    const _ocppAuth2 = OcpiTokensMapper.mapOcpiTokenToOcppAuthorization(
       token2 as TokenDTO,
     );
 


### PR DESCRIPTION
feat: created new ValidatedResponseSchema annotation which reused ResponseSchema annotation directly but also sets the class into reflect metadata and then created ResponseValidationMiddleware which gets the class and annotation and builds the DTO via plainToClass and runs validation on the response that is going to be sent in response

To use, all we have to do is switch occurrences of @ResponseSchema to use @ValidatedResponseSchema which will enable the ResponseValidationMiddleware.

<img width="1125" alt="Screenshot 2024-07-09 at 3 57 24 PM" src="https://github.com/citrineos/citrineos-ocpi/assets/63012697/13e45bb8-481a-4c0d-b9b3-9dce1630a8aa">
<img width="1112" alt="Screenshot 2024-07-09 at 3 57 10 PM" src="https://github.com/citrineos/citrineos-ocpi/assets/63012697/e0773397-e6d7-4d6c-9eff-099091d1835e">
