### PR TITLE
Creating BodyWithExample Annotation

### DIFF
--- a/00_Base/src/index.ts
+++ b/00_Base/src/index.ts
@@ -57,7 +57,10 @@ export { ClientInformationRepository } from './repository/ClientInformationRepos
 export { EndpointRepository } from './repository/EndpointRepository';
 export { SessionChargingProfileRepository } from './repository/SessionChargingProfileRepository';
 
-export { ClientInformation, ClientInformationProps } from './model/ClientInformation';
+export {
+  ClientInformation,
+  ClientInformationProps,
+} from './model/ClientInformation';
 export { ClientCredentialsRole } from './model/ClientCredentialsRole';
 export { fromCredentialsRoleDTO } from './model/ClientCredentialsRole';
 export { OcpiServerConfig } from './config/ocpi.server.config';
@@ -192,6 +195,7 @@ export { CdrBroadcaster } from './broadcaster/cdr.broadcaster';
 export { LocationsBroadcaster } from './broadcaster/locations.broadcaster';
 export { PaginatedTariffResponse } from './model/DTO/TariffDTO';
 export { OcpiLocation, OcpiLocationProps } from './model/OcpiLocation';
+export { BodyWithExample } from './util/decorators/BodyWithExample';
 
 useContainer(Container);
 

--- a/00_Base/src/openapi-spec-helper/generate.spec.helpers.ts
+++ b/00_Base/src/openapi-spec-helper/generate.spec.helpers.ts
@@ -15,6 +15,7 @@ import { HttpHeader } from '@citrineos/base';
 import { ENUM_QUERY_PARAM } from '../util/decorators/enum.query.param';
 import { ParamMetadataArgs } from 'routing-controllers/types/metadata/args/ParamMetadataArgs';
 import { Constructable } from 'typedi';
+import { BODY_WITH_EXAMPLE_PARAM } from '../util/decorators/BodyWithExample';
 
 /** Return full Express path of given route. */
 export function getFullExpressPath(route: IRoute): string {
@@ -233,14 +234,26 @@ export function getRequestBody(route: IRoute): oa.RequestBodyObject | void {
     //   'items' in bodySchema && bodySchema.items ? bodySchema.items : bodySchema;
     // const $ref = { $ref: ref };
 
-    return {
-      content: {
-        'application/json': {
-          schema: bodyParamsSchema
-            ? { allOf: [bodySchema, bodyParamsSchema] }
-            : bodySchema,
-        },
+    const content: any = {
+      'application/json': {
+        schema: bodyParamsSchema
+          ? { allOf: [bodySchema, bodyParamsSchema] }
+          : bodySchema,
       },
+    };
+
+    const example = Reflect.getMetadata(
+      BODY_WITH_EXAMPLE_PARAM,
+      bodyMeta.object,
+      bodyMeta.method,
+    );
+
+    if (example) {
+      content['application/json']['example'] = example;
+    }
+
+    return {
+      content,
       required: isRequired(bodyMeta, route),
     };
   } else if (bodyParamsSchema) {

--- a/00_Base/src/util/decorators/BodyWithExample.ts
+++ b/00_Base/src/util/decorators/BodyWithExample.ts
@@ -1,0 +1,16 @@
+import { Body } from 'routing-controllers';
+
+export const BODY_WITH_EXAMPLE_PARAM = 'BodyWithExample';
+
+export const BodyWithExample = (example: any) =>
+  function (object: NonNullable<unknown>, methodName: string, index: number) {
+    Body()(object, methodName, index);
+
+    // Add custom metadata for additional use cases
+    Reflect.defineMetadata(
+      BODY_WITH_EXAMPLE_PARAM,
+      example,
+      object,
+      methodName,
+    );
+  };

--- a/03_Modules/Tokens/src/module/api.ts
+++ b/03_Modules/Tokens/src/module/api.ts
@@ -20,6 +20,7 @@ import {
   AsOcpiFunctionalEndpoint,
   AsyncJobStatusDTO,
   BaseController,
+  BodyWithExample,
   EnumQueryParam,
   FunctionalEndpointParams,
   generateMockOcpiResponse,
@@ -40,10 +41,30 @@ import {
   versionIdParam,
   VersionNumber,
   VersionNumberParam,
+  WhitelistType,
   WrongClientAccessException,
 } from '@citrineos/ocpi-base';
 import { ITokensModuleApi } from './interface';
-import { plainToInstance } from 'class-transformer';
+
+const MockPutTokenBody = {
+  country_code: 'MSP',
+  party_id: 'US',
+  uid: 'SOMEUID',
+  type: 'RFID',
+  contract_id: 'contract_id',
+  issuer: 'issuer',
+  valid: true,
+  whitelist: WhitelistType.ALLOWED,
+  last_updated: '2024-07-10T18:00:40.087Z',
+  visual_number: 'visual_number',
+  group_id: 'group_id',
+  language: 'language',
+  default_profile_type: 'default_profile_type',
+  energy_contract: {
+    supplier_name: 'supplier_name',
+    contract_id: 'contract_id',
+  },
+};
 
 @JsonController(`/:${versionIdParam}/${ModuleId.Tokens}`)
 @Service()
@@ -115,7 +136,7 @@ export class TokensModuleApi
     @Param('partyId') partyId: string,
     @Param('tokenId') tokenId: string,
     @FunctionalEndpointParams() ocpiHeader: OcpiHeaders,
-    @Body() tokenDTO: TokenDTO,
+    @BodyWithExample(MockPutTokenBody) tokenDTO: TokenDTO,
     @EnumQueryParam('type', TokenType, 'TokenType') type?: TokenType,
   ): Promise<OcpiEmptyResponse> {
     console.log('putToken', countryCode, partyId, tokenId, tokenDTO, type);


### PR DESCRIPTION
feat: creating BodyWithExample annotation which wraps the @Body() annotation but also allows us to pass an example body that will be used when generating the OpenAPI spec
![Screenshot 2024-07-10 at 2 19 37 PM](https://github.com/citrineos/citrineos-ocpi/assets/63012697/c1552fe5-97b8-4309-9b6c-d5fd60b0d285)
![Screenshot 2024-07-10 at 2 20 01 PM](https://github.com/citrineos/citrineos-ocpi/assets/63012697/77e3d81b-af19-47b8-9688-60b76305b8f1)
