### PR TITLE
Fix/sessions broadcaster push put vs patch

### DIFF
--- a/00_Base/src/trigger/param/sessions/patch.session.params.ts
+++ b/00_Base/src/trigger/param/sessions/patch.session.params.ts
@@ -1,5 +1,6 @@
 import { OcpiParams } from '../../util/ocpi.params';
 import { IsNotEmpty, IsString, Length } from 'class-validator';
+import { Session } from '../../../model/Session';
 
 export class PatchSessionParams extends OcpiParams {
   @IsString()
@@ -7,5 +8,12 @@ export class PatchSessionParams extends OcpiParams {
   @Length(36, 36)
   sessionId!: string;
 
-  requestBody!: { [key: string]: object };
+  requestBody!: Partial<Session>;
+
+  static build(sessionId: string, requestBody: Partial<Session>) {
+    const params = new PatchSessionParams();
+    params.sessionId = sessionId;
+    params.requestBody = requestBody;
+    return params;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "sync-db": "ts-node ./db.sync.ts",
     "init-db": "sequelize-cli db:migrate --debug && sequelize-cli db:migrate:schema:timestamps:add --debug",
     "seed-db": "sequelize-cli db:seed:all --debug",
+    "clean-db": "sequelize-cli db:seed:undo:all --debug",
+    "clean-and-seed-db": "npm run clean-db && npm run seed-db",
     "start-mock-emsp": "npm run build && nodemon ./mock-client/index.ts --config ./mock-client/nodemon.json",
     "start-mockoon": "npm run start-mock-emsp && mockoon-cli start --data http://localhost:8086/docs/spec --port 3000",
     "install-all": "npm i --workspaces --verbose",

--- a/seeders/20240619140739-base-tokens.ts
+++ b/seeders/20240619140739-base-tokens.ts
@@ -1,12 +1,19 @@
 'use strict';
 
-import { QueryInterface } from 'sequelize';
+import { QueryInterface, QueryOptions } from 'sequelize';
 import {
   OcpiSequelizeInstance,
   OcpiServerConfig,
   OcpiTokensMapper,
   TokenDTO,
 } from '@citrineos/ocpi-base';
+import {
+  AdditionalInfo,
+  Authorization,
+  IdToken,
+  IdTokenInfo,
+} from '../../citrineos-core/01_Data';
+import { AdditionalGeoLocation } from '@citrineos/ocpi-base/dist/model/AdditionalGeoLocation';
 
 const _sequelize = new OcpiSequelizeInstance(new OcpiServerConfig()); // needed to init models
 
@@ -15,54 +22,201 @@ module.exports = {
   up: async (_queryInterface: QueryInterface) => {
     const token1 = {
       country_code: 'US',
-      party_id: 'S44',
-      uid: '123e4567-e89b-12d3-a456-426614174000',
-      type: 'RFID',
+      party_id: 'MSP',
+      uid: '001',
+      type: 'APP_USER',
       contract_id: 'contract_001',
       visual_number: 'VIS001',
-      issuer: 'Issuer1',
+      issuer: 'Issuer001',
       group_id: 'group_001',
       valid: true,
       whitelist: 'ALWAYS',
       language: 'EN',
-      default_profile_type: 'default',
-      energy_contract: null,
+      default_profile_type: 'premium',
+      energy_contract: {
+        supplier_name: 'Supplier001',
+        contract_id: 'contract_001',
+      },
       last_updated: new Date(),
-      createdAt: new Date(),
-      updatedAt: new Date(),
     };
 
-    const token2 = {
-      country_code: 'US',
-      party_id: 'XYZ',
-      uid: '987e6543-e21b-65d4-b789-123456789012',
-      type: 'APP_USER',
-      contract_id: 'contract_002',
-      visual_number: 'VIS002',
-      issuer: 'Issuer2',
-      group_id: 'group_002',
-      valid: false,
-      whitelist: 'ALWAYS',
-      language: 'EN',
-      default_profile_type: 'premium',
-      energy_contract: null,
-      last_updated: new Date(),
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
-    const ocppAuth1 = OcpiTokensMapper.mapOcpiTokenToOcppAuthorization(
+    const ocppAuth = OcpiTokensMapper.mapOcpiTokenToOcppAuthorization(
       token1 as TokenDTO,
     );
-    const ocppAuth2 = OcpiTokensMapper.mapOcpiTokenToOcppAuthorization(
-      token2 as TokenDTO,
+
+    const additionalInfoRecord: any = await _queryInterface.bulkInsert(
+      'AdditionalInfos',
+      [
+        {
+          ...ocppAuth.idToken.additionalInfo![0],
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+      {
+        returning: true,
+        ignoreDuplicates: true,
+      } as QueryOptions,
     );
 
-    // TODO fix seeders after changing ocpi tokens mapper
-    // await ocppAuth1.save();
-    // await ocppAuth2.save();
+    const idTokenRecord: any = await _queryInterface.bulkInsert(
+      'IdTokens',
+      [
+        {
+          idToken: ocppAuth.idToken.idToken,
+          type: ocppAuth.idToken.type,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+      {
+        returning: true,
+        ignoreDuplicates: true,
+      } as QueryOptions,
+    );
+
+    const groupIdTokenRecord: any = await _queryInterface.bulkInsert(
+      'IdTokens',
+      [
+        {
+          ...ocppAuth.idTokenInfo?.groupIdToken,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+      {
+        returning: true,
+        ignoreDuplicates: true,
+      } as QueryOptions,
+    );
+
+    if (!groupIdTokenRecord || groupIdTokenRecord.length === 0) {
+      groupIdTokenRecord[0] = (
+        await IdToken.findOne({
+          where: {
+            idToken: ocppAuth.idTokenInfo?.groupIdToken?.idToken,
+            type: ocppAuth.idTokenInfo?.groupIdToken?.type,
+          },
+        })
+      )?.dataValues;
+    }
+
+    const idTokenInfoRecord: any = await _queryInterface.bulkInsert(
+      'IdTokenInfos',
+      [
+        {
+          status: ocppAuth.idTokenInfo?.status,
+          cacheExpiryDateTime: ocppAuth.idTokenInfo?.cacheExpiryDateTime,
+          chargingPriority: ocppAuth.idTokenInfo?.chargingPriority,
+          language1: ocppAuth.idTokenInfo?.language1,
+          language2: ocppAuth.idTokenInfo?.language2,
+          personalMessage: ocppAuth.idTokenInfo?.personalMessage,
+          groupIdTokenId: groupIdTokenRecord[0].id,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+      {
+        returning: true,
+        ignoreDuplicates: true,
+      } as QueryOptions,
+    );
+
+    if (!idTokenRecord || idTokenRecord.length === 0) {
+      idTokenRecord[0] = (
+        await IdToken.findOne({
+          where: {
+            idToken: ocppAuth.idToken.idToken,
+            type: ocppAuth.idToken.type,
+          },
+        })
+      )?.dataValues;
+    }
+
+    if (!additionalInfoRecord || additionalInfoRecord.length === 0) {
+      additionalInfoRecord[0] = (
+        await AdditionalInfo.findOne({
+          where: {
+            additionalIdToken:
+              ocppAuth.idToken.additionalInfo![0].additionalIdToken,
+            type: ocppAuth.idToken.additionalInfo![0].type,
+          },
+        })
+      )?.dataValues;
+    }
+
+    const idTokenAdditionalInfosRecord: any = await _queryInterface.bulkInsert(
+      'IdTokenAdditionalInfos',
+      [
+        {
+          idTokenId: idTokenRecord[0].id,
+          additionalInfoId: additionalInfoRecord[0].id,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+      {
+        returning: true,
+        ignoreDuplicates: true,
+      } as QueryOptions,
+    );
+
+    const authorizationRecord: any = await _queryInterface.bulkInsert(
+      'Authorizations',
+      [
+        {
+          idTokenId: idTokenRecord[0].id,
+          idTokenInfoId: idTokenInfoRecord[0].id,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+      {
+        returning: true,
+        ignoreDuplicates: true,
+      } as QueryOptions,
+    );
+
+    if (!authorizationRecord || authorizationRecord.length === 0) {
+      authorizationRecord[0] = (
+        await Authorization.findOne({
+          where: {
+            idTokenId: idTokenRecord[0].id,
+            idTokenInfoId: idTokenInfoRecord[0].id,
+          },
+        })
+      )?.dataValues;
+    }
+
+    const ocpiTokenRecord: any = await _queryInterface.bulkInsert(
+      'OcpiTokens',
+      [
+        {
+          authorization_id: authorizationRecord[0].id,
+          country_code: token1.country_code,
+          party_id: token1.party_id,
+          type: token1.type,
+          visual_number: token1.visual_number,
+          issuer: token1.issuer,
+          whitelist: token1.whitelist,
+          default_profile_type: token1.default_profile_type,
+          energy_contract: JSON.stringify(token1.energy_contract),
+          last_updated: token1.last_updated,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+      {
+        returning: true,
+        ignoreDuplicates: true,
+      } as QueryOptions,
+    );
   },
 
   down: async (queryInterface: QueryInterface) => {
-    await queryInterface.bulkDelete('Tokens', {}, {});
+    await queryInterface.bulkDelete('OcpiTokens', {}, {});
+    await queryInterface.bulkDelete('Authorizations', {}, {
+      cascade: true,
+    } as QueryOptions);
   },
 };

--- a/seeders/20240619140739-base-tokens.ts
+++ b/seeders/20240619140739-base-tokens.ts
@@ -23,7 +23,7 @@ module.exports = {
     const token1 = {
       country_code: 'US',
       party_id: 'MSP',
-      uid: '001',
+      uid: '1',
       type: 'APP_USER',
       contract_id: 'contract_001',
       visual_number: 'VIS001',
@@ -63,6 +63,7 @@ module.exports = {
       'IdTokens',
       [
         {
+          id: 1,
           idToken: ocppAuth.idToken.idToken,
           type: ocppAuth.idToken.type,
           createdAt: new Date(),
@@ -214,8 +215,22 @@ module.exports = {
   },
 
   down: async (queryInterface: QueryInterface) => {
-    await queryInterface.bulkDelete('OcpiTokens', {}, {});
     await queryInterface.bulkDelete('Authorizations', {}, {
+      cascade: true,
+    } as QueryOptions);
+    await queryInterface.bulkDelete('IdTokenInfos', {}, {
+      cascade: true,
+    } as QueryOptions);
+    await queryInterface.bulkDelete('IdTokens', {}, {
+      cascade: true,
+    } as QueryOptions);
+    await queryInterface.bulkDelete('IdTokenAdditionalInfos', {}, {
+      cascade: true,
+    } as QueryOptions);
+    await queryInterface.bulkDelete('AdditionalInfos', {}, {
+      cascade: true,
+    } as QueryOptions);
+    await queryInterface.bulkDelete('OcpiTokens', {}, {
       cascade: true,
     } as QueryOptions);
   },

--- a/seeders/20240703120234-locations.ts
+++ b/seeders/20240703120234-locations.ts
@@ -16,7 +16,8 @@ const DUMMY_IDS = {
 /** @type {import('sequelize-cli').Migration} */
 export = {
   up: async (queryInterface: QueryInterface) => {
-    const createEvses: any = async () => await queryInterface.bulkInsert(
+    const createEvses: any = async () =>
+      await queryInterface.bulkInsert(
         'Evses',
         [
           {
@@ -104,7 +105,8 @@ export = {
       ]);
     };
 
-    const createChargingStationComponent: any = async () => await queryInterface.bulkInsert(
+    const createChargingStationComponent: any = async () =>
+      await queryInterface.bulkInsert(
         'Components',
         [
           {
@@ -119,7 +121,8 @@ export = {
         } as QueryOptions,
       );
 
-    const createEvseComponent: any = async (evse: any) => await queryInterface.bulkInsert(
+    const createEvseComponent: any = async (evse: any) =>
+      await queryInterface.bulkInsert(
         'Components',
         [
           {
@@ -135,7 +138,8 @@ export = {
         } as QueryOptions,
       );
 
-    const createConnectorComponent: any = async (evse: any) => await queryInterface.bulkInsert(
+    const createConnectorComponent: any = async (evse: any) =>
+      await queryInterface.bulkInsert(
         'Components',
         [
           {
@@ -212,7 +216,8 @@ export = {
 
     const createChargingStationVariableAttributes: any = async (
       chargingStationComponent: any,
-    ) => await queryInterface.bulkInsert('VariableAttributes', [
+    ) =>
+      await queryInterface.bulkInsert('VariableAttributes', [
         {
           stationId: 1,
           variableId: 4,
@@ -239,7 +244,8 @@ export = {
         },
       ]);
 
-    const createEvseVariableAttributes: any = async (evseComponent: any) => await queryInterface.bulkInsert('VariableAttributes', [
+    const createEvseVariableAttributes: any = async (evseComponent: any) =>
+      await queryInterface.bulkInsert('VariableAttributes', [
         {
           stationId: 1,
           variableId: 18,
@@ -284,7 +290,8 @@ export = {
 
     const createConnectorVariableAttributes: any = async (
       connectorComponent: any,
-    ) => await queryInterface.bulkInsert('VariableAttributes', [
+    ) =>
+      await queryInterface.bulkInsert('VariableAttributes', [
         {
           stationId: 1,
           variableId: 18,

--- a/seeders/20240703120234-locations.ts
+++ b/seeders/20240703120234-locations.ts
@@ -1,0 +1,386 @@
+'use strict';
+
+import { QueryInterface, QueryOptions } from 'sequelize';
+import { OcpiLocationProps } from '@citrineos/ocpi-base';
+import { Sequelize } from 'sequelize-typescript';
+
+const START_ID = 1;
+
+const DUMMY_IDS = {
+  OCPI_LOCATION_ID: START_ID,
+  LOCATION_ID: START_ID,
+  EVSE_ID: START_ID,
+  CHARGING_STATION: START_ID,
+};
+
+/** @type {import('sequelize-cli').Migration} */
+export = {
+  up: async (queryInterface: QueryInterface) => {
+    const createEvses: any = async () => await queryInterface.bulkInsert(
+        'Evses',
+        [
+          {
+            databaseId: DUMMY_IDS.EVSE_ID,
+            id: DUMMY_IDS.EVSE_ID,
+            connectorId: 1,
+            createdAt: new Date(0),
+            updatedAt: new Date(),
+          },
+        ],
+        {
+          returning: true,
+        } as QueryOptions,
+      );
+
+    const createLocations: any = async () =>
+      await queryInterface.bulkInsert(
+        'Locations',
+        [
+          {
+            name: 'name',
+            address: 'address',
+            city: 'city',
+            postalCode: 'postalCode',
+            state: 'state',
+            country: 'country',
+            coordinates: Sequelize.fn('ST_GeomFromText', 'POINT(74 41)'), // converts to needed Geometry object
+            createdAt: new Date(0),
+            updatedAt: new Date(),
+          },
+        ],
+        {
+          returning: true,
+        } as QueryOptions,
+      );
+
+    const createOcpiLocations = async (location: any) => {
+      await queryInterface.bulkInsert('OcpiLocations', [
+        {
+          [OcpiLocationProps.citrineLocationId]: location.id,
+          [OcpiLocationProps.publish]: true,
+          [OcpiLocationProps.lastUpdated]: new Date(),
+          [OcpiLocationProps.partyId]: 'CPO',
+          [OcpiLocationProps.countryCode]: 'US',
+          createdAt: new Date(0),
+          updatedAt: new Date(),
+        },
+      ]);
+    };
+
+    const createOcpiEvse = async () => {
+      await queryInterface.bulkInsert('OcpiEvses', [
+        {
+          evseId: DUMMY_IDS.EVSE_ID,
+          stationId: DUMMY_IDS.CHARGING_STATION,
+          createdAt: new Date(0),
+          updatedAt: new Date(),
+          lastUpdated: new Date(),
+        },
+      ]);
+    };
+
+    const createOcpiConnectors = async () => {
+      await queryInterface.bulkInsert('OcpiConnectors', [
+        {
+          connectorId: 1,
+          evseId: DUMMY_IDS.EVSE_ID,
+          stationId: DUMMY_IDS.CHARGING_STATION,
+          createdAt: new Date(0),
+          updatedAt: new Date(),
+          lastUpdated: new Date(),
+        },
+      ]);
+    };
+
+    const createChargingStation = async (location: any) => {
+      await queryInterface.bulkInsert('ChargingStations', [
+        {
+          id: DUMMY_IDS.CHARGING_STATION,
+          isOnline: true,
+          locationId: location.id,
+          createdAt: new Date(0),
+          updatedAt: new Date(),
+        },
+      ]);
+    };
+
+    const createChargingStationComponent: any = async () => await queryInterface.bulkInsert(
+        'Components',
+        [
+          {
+            name: 'ChargingStation',
+            instance: 1,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ],
+        {
+          returning: true,
+        } as QueryOptions,
+      );
+
+    const createEvseComponent: any = async (evse: any) => await queryInterface.bulkInsert(
+        'Components',
+        [
+          {
+            name: 'EVSE',
+            instance: 1,
+            evseDatabaseId: evse.id,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ],
+        {
+          returning: true,
+        } as QueryOptions,
+      );
+
+    const createConnectorComponent: any = async (evse: any) => await queryInterface.bulkInsert(
+        'Components',
+        [
+          {
+            name: 'Connector',
+            instance: 1,
+            evseDatabaseId: evse.id,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ],
+        {
+          returning: true,
+        } as QueryOptions,
+      );
+
+    const createVariables: any = async () => {
+      await queryInterface.bulkInsert('Variables', [
+        {
+          id: 4,
+          name: 'Mode',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 5,
+          name: 'VendorName',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 6,
+          name: 'SerialNumber',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 18,
+          name: 'AvailabilityState',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 19,
+          name: 'EvseId',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 20,
+          name: 'DCVoltage',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 21,
+          name: 'DCCurrent',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 22,
+          name: 'Power',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 23,
+          name: 'ConnectorType',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+    };
+
+    const createChargingStationVariableAttributes: any = async (
+      chargingStationComponent: any,
+    ) => await queryInterface.bulkInsert('VariableAttributes', [
+        {
+          stationId: 1,
+          variableId: 4,
+          componentId: chargingStationComponent.id,
+          value: 'localCharger',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          stationId: 1,
+          variableId: 5,
+          componentId: chargingStationComponent.id,
+          value: 'local',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          stationId: 1,
+          variableId: 6,
+          componentId: chargingStationComponent.id,
+          value: 'SERIALCHARGER01',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+
+    const createEvseVariableAttributes: any = async (evseComponent: any) => await queryInterface.bulkInsert('VariableAttributes', [
+        {
+          stationId: 1,
+          variableId: 18,
+          componentId: evseComponent.id,
+          value: 'Available',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          stationId: 1,
+          variableId: 19,
+          componentId: evseComponent.id,
+          value: 'EvseId1',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          stationId: 1,
+          variableId: 20,
+          componentId: evseComponent.id,
+          value: 1,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          stationId: 1,
+          variableId: 21,
+          componentId: evseComponent.id,
+          value: 1,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          stationId: 1,
+          variableId: 22,
+          componentId: evseComponent.id,
+          value: 1,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+
+    const createConnectorVariableAttributes: any = async (
+      connectorComponent: any,
+    ) => await queryInterface.bulkInsert('VariableAttributes', [
+        {
+          stationId: 1,
+          variableId: 18,
+          componentId: connectorComponent.id,
+          value: 'Available',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          stationId: 1,
+          variableId: 23,
+          componentId: connectorComponent.id,
+          value: 'cCCS1',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+
+    try {
+      const location = await createLocations();
+      await createOcpiLocations(location[0]);
+      await createChargingStation(location[0]);
+      const evse = await createEvses();
+      await createOcpiEvse();
+      await createOcpiConnectors();
+      const chargingStationComponent = await createChargingStationComponent();
+      const evseComponent = await createEvseComponent(evse[0]);
+      const connectorComponent = await createConnectorComponent(evse[0]);
+      await createVariables();
+      await createChargingStationVariableAttributes(
+        chargingStationComponent[0],
+      );
+      await createEvseVariableAttributes(evseComponent[0]);
+      await createConnectorVariableAttributes(connectorComponent[0]);
+
+      console.log('Location Data seeded successfully');
+    } catch (error) {
+      console.error('Error seeding Transactions data:', error);
+      throw error;
+    }
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    try {
+      // Delete EVSE
+      await queryInterface.bulkDelete('Evses', {}, {
+        truncate: true,
+        cascade: true,
+      } as QueryOptions);
+
+      // Delete ChargingStation
+      await queryInterface.bulkDelete('ChargingStations', {}, {
+        cascade: true,
+      } as QueryOptions);
+
+      // Delete Location
+      await queryInterface.bulkDelete('Locations', {}, {
+        cascade: true,
+      } as QueryOptions);
+
+      // Delete OCPILocations
+      await queryInterface.bulkDelete('OcpiLocations', {}, {
+        truncate: true,
+        cascade: true,
+      } as QueryOptions);
+
+      // Delete OCPILocations
+      await queryInterface.bulkDelete('OcpiEvses', {}, {
+        truncate: true,
+        cascade: true,
+      } as QueryOptions);
+
+      // Delete OCPILocations
+      await queryInterface.bulkDelete('OcpiConnectors', {}, {
+        truncate: true,
+        cascade: true,
+      } as QueryOptions);
+
+      await queryInterface.bulkDelete('Variables', {}, {
+        truncate: true,
+        cascade: true,
+      } as QueryOptions);
+
+      await queryInterface.bulkDelete('VariableAttributes', {}, {
+        truncate: true,
+        cascade: true,
+      } as QueryOptions);
+
+      await queryInterface.bulkDelete('Components', {}, {
+        truncate: true,
+        cascade: true,
+      } as QueryOptions);
+
+      console.log('Transaction data reverted successfully');
+    } catch (error) {
+      console.error('Error reverting Transactions data:', error);
+    }
+  },
+};

--- a/seeders/20240703120234-transactions.ts
+++ b/seeders/20240703120234-transactions.ts
@@ -3,13 +3,10 @@
 import { QueryInterface, QueryOptions } from 'sequelize';
 import {
   ChargingStateEnumType,
-  IdTokenEnumType,
   ReasonEnumType,
   TransactionEventEnumType,
   TriggerReasonEnumType,
 } from '../../citrineos-core/00_Base';
-import { OcpiLocationProps } from '@citrineos/ocpi-base';
-import { Sequelize } from 'sequelize-typescript';
 
 const START_ID = 1;
 
@@ -17,7 +14,7 @@ const DUMMY_IDS = {
   OCPI_LOCATION_ID: START_ID,
   LOCATION_ID: START_ID,
   EVSE_ID: START_ID,
-  ID_TOKEN: `IDTOKEN-0000${START_ID}`,
+  ID_TOKEN: START_ID,
   ID_TOKEN_ID: START_ID,
   CHARGING_STATION: START_ID,
   TRANSACTION_ID: START_ID,
@@ -30,7 +27,7 @@ const DUMMY_IDS = {
 /** @type {import('sequelize-cli').Migration} */
 export = {
   up: async (queryInterface: QueryInterface) => {
-    const createTransaction = async () =>
+    const createTransaction: any = async () =>
       await queryInterface.bulkInsert(
         'Transactions',
         [
@@ -44,7 +41,7 @@ export = {
             totalKwh: 40.5,
             stoppedReason: ReasonEnumType.Remote,
             remoteStartId: 1,
-            createdAt: new Date(Date.now() - 7200000), // 2 hours ago
+            createdAt: new Date('2024-04-03T13:55:49.466Z'),
             updatedAt: new Date(),
           },
         ],
@@ -61,7 +58,7 @@ export = {
             id: DUMMY_IDS.START_TRANSACTION_EVENT,
             stationId: DUMMY_IDS.CHARGING_STATION,
             eventType: TransactionEventEnumType.Started,
-            timestamp: new Date(Date.now() - 7200000).toISOString(), // 2 hours ago
+            timestamp: new Date('2024-04-03T13:55:49.466Z').toISOString(),
             triggerReason: TriggerReasonEnumType.Authorized,
             seqNo: 1,
             transactionDatabaseId: transactionDatabaseId,
@@ -74,14 +71,14 @@ export = {
             transactionInfo: JSON.stringify({
               transactionId: DUMMY_IDS.TRANSACTION_ID,
             }),
-            createdAt: new Date(Date.now() - 7200000),
-            updatedAt: new Date(Date.now() - 7200000),
+            createdAt: new Date('2024-04-03T13:55:49.466Z'),
+            updatedAt: new Date('2024-04-03T13:55:49.466Z'),
           },
           {
             id: DUMMY_IDS.UPDATE_TRANSACTION_EVENT_1,
             stationId: DUMMY_IDS.CHARGING_STATION,
             eventType: TransactionEventEnumType.Updated,
-            timestamp: new Date(Date.now() - 3600000).toISOString(), // 1 hour ago
+            timestamp: new Date('2024-04-03T14:00:00.147Z').toISOString(),
             triggerReason: TriggerReasonEnumType.MeterValuePeriodic,
             seqNo: 2,
             transactionDatabaseId: transactionDatabaseId,
@@ -93,33 +90,14 @@ export = {
             transactionInfo: JSON.stringify({
               transactionId: DUMMY_IDS.TRANSACTION_ID,
             }),
-            createdAt: new Date(Date.now() - 3600000),
-            updatedAt: new Date(Date.now() - 3600000),
-          },
-          {
-            id: DUMMY_IDS.UPDATE_TRANSACTION_EVENT_2,
-            stationId: DUMMY_IDS.CHARGING_STATION,
-            eventType: TransactionEventEnumType.Updated,
-            timestamp: new Date(Date.now() - 1800000).toISOString(), // 30 minutes ago
-            triggerReason: TriggerReasonEnumType.MeterValuePeriodic,
-            seqNo: 3,
-            transactionDatabaseId: transactionDatabaseId,
-            offline: false,
-            numberOfPhasesUsed: 3,
-            cableMaxCurrent: 32,
-            evseId: DUMMY_IDS.EVSE_ID,
-            idTokenId: DUMMY_IDS.ID_TOKEN_ID,
-            transactionInfo: JSON.stringify({
-              transactionId: DUMMY_IDS.TRANSACTION_ID,
-            }),
-            createdAt: new Date(Date.now() - 1800000),
-            updatedAt: new Date(Date.now() - 1800000),
+            createdAt: new Date('2024-04-03T14:00:00.147Z'),
+            updatedAt: new Date('2024-04-03T14:00:00.147Z'),
           },
           {
             id: DUMMY_IDS.END_TRANSACTION_EVENT,
             stationId: DUMMY_IDS.CHARGING_STATION,
             eventType: TransactionEventEnumType.Ended,
-            timestamp: new Date().toISOString(), // Now
+            timestamp: new Date('2024-04-03T14:01:23.297Z').toISOString(),
             triggerReason: TriggerReasonEnumType.StopAuthorized,
             seqNo: 4,
             transactionDatabaseId: transactionDatabaseId,
@@ -131,8 +109,8 @@ export = {
             transactionInfo: JSON.stringify({
               transactionId: DUMMY_IDS.TRANSACTION_ID,
             }),
-            createdAt: new Date(0),
-            updatedAt: new Date(),
+            createdAt: new Date('2024-04-03T14:01:23.297Z'),
+            updatedAt: new Date('2024-04-03T14:01:23.297Z'),
           },
         ],
         {},
@@ -143,76 +121,1075 @@ export = {
         'MeterValues',
         [
           {
-            transactionEventId: DUMMY_IDS.START_TRANSACTION_EVENT,
             transactionDatabaseId: transactionDatabaseId,
             sampledValue: JSON.stringify([
               {
+                context: 'Transaction.Begin',
+                location: 'Outlet',
                 measurand: 'Energy.Active.Import.Register',
-                phase: null,
                 unitOfMeasure: {
-                  unit: 'kWh',
-                  multiplier: 1,
+                  unit: 'Wh',
+                },
+                value: 0,
+              },
+              {
+                context: 'Transaction.Begin',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L1',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 0,
+              },
+              {
+                context: 'Transaction.Begin',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L2',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 0,
+              },
+              {
+                context: 'Transaction.Begin',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L3',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 0,
+              },
+              {
+                context: 'Transaction.Begin',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'L1',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 0,
+              },
+              {
+                context: 'Transaction.Begin',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'L2',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 0,
+              },
+              {
+                context: 'Transaction.Begin',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'L3',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 0,
+              },
+              {
+                context: 'Transaction.Begin',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'N',
+                unitOfMeasure: {
+                  unit: 'A',
                 },
                 value: 0,
               },
             ]),
-            timestamp: new Date(Date.now() - 7200000).toISOString(),
-            createdAt: new Date(Date.now() - 7200000),
-            updatedAt: new Date(Date.now() - 7200000),
+            timestamp: new Date('2024-04-03T13:55:48.914Z').toISOString(),
+            createdAt: new Date('2024-04-03T13:55:48.914Z'),
+            updatedAt: new Date('2024-04-03T13:55:48.914Z'),
           },
           {
-            transactionEventId: DUMMY_IDS.UPDATE_TRANSACTION_EVENT_1,
             transactionDatabaseId: transactionDatabaseId,
             sampledValue: JSON.stringify([
               {
+                context: 'Sample.Clock',
+                location: 'Outlet',
                 measurand: 'Energy.Active.Import.Register',
-                phase: null,
                 unitOfMeasure: {
-                  unit: 'kWh',
-                  multiplier: 1,
+                  unit: 'Wh',
                 },
-                value: 20.5,
+                value: 21.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L1',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 7.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L2',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 7.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L3',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 7.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Voltage',
+                phase: 'L1-N',
+                unitOfMeasure: {
+                  unit: 'V',
+                },
+                value: 225.00149536132813,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Voltage',
+                phase: 'L2-N',
+                unitOfMeasure: {
+                  unit: 'V',
+                },
+                value: 225.00149536132813,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Voltage',
+                phase: 'L3-N',
+                unitOfMeasure: {
+                  unit: 'V',
+                },
+                value: 225.00149536132813,
               },
             ]),
-            timestamp: new Date(Date.now() - 3600000).toISOString(),
-            createdAt: new Date(Date.now() - 3600000),
-            updatedAt: new Date(Date.now() - 3600000),
+            timestamp: new Date('2024-04-03T13:55:59.015Z').toISOString(),
+            createdAt: new Date('2024-04-03T13:55:59.015Z'),
+            updatedAt: new Date('2024-04-03T13:55:59.015Z'),
           },
           {
-            transactionEventId: DUMMY_IDS.UPDATE_TRANSACTION_EVENT_2,
             transactionDatabaseId: transactionDatabaseId,
             sampledValue: JSON.stringify([
               {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
                 measurand: 'Energy.Active.Import.Register',
-                phase: null,
                 unitOfMeasure: {
-                  unit: 'kWh',
-                  multiplier: 1,
+                  unit: 'Wh',
                 },
-                value: 35.0,
+                value: 171.0,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L1',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 57.0,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L2',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 57.0,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L3',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 57.0,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'L1',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 16.107704162597656,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'L2',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 16.107704162597656,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'L3',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 16.107704162597656,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'N',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 0.201346293091774,
               },
             ]),
-            timestamp: new Date(Date.now() - 1800000).toISOString(),
-            createdAt: new Date(Date.now() - 1800000),
-            updatedAt: new Date(Date.now() - 1800000),
+            timestamp: new Date('2024-04-03T13:56:49.541Z').toISOString(),
+            createdAt: new Date('2024-04-03T13:56:49.541Z'),
+            updatedAt: new Date('2024-04-03T13:56:49.541Z'),
           },
           {
-            transactionEventId: DUMMY_IDS.END_TRANSACTION_EVENT,
             transactionDatabaseId: transactionDatabaseId,
             sampledValue: JSON.stringify([
               {
+                context: 'Sample.Clock',
+                location: 'Outlet',
                 measurand: 'Energy.Active.Import.Register',
-                phase: null,
                 unitOfMeasure: {
-                  unit: 'kWh',
-                  multiplier: 1,
+                  unit: 'Wh',
                 },
-                value: 40.5,
+                value: 200.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L1',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 67.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L2',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 67.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L3',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 67.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Voltage',
+                phase: 'L1-N',
+                unitOfMeasure: {
+                  unit: 'V',
+                },
+                value: 221.95834350585938,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Voltage',
+                phase: 'L2-N',
+                unitOfMeasure: {
+                  unit: 'V',
+                },
+                value: 221.95834350585938,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Voltage',
+                phase: 'L3-N',
+                unitOfMeasure: {
+                  unit: 'V',
+                },
+                value: 221.95834350585938,
               },
             ]),
-            timestamp: new Date().toISOString(),
-            createdAt: new Date(0),
-            updatedAt: new Date(),
+            timestamp: new Date('2024-04-03T13:56:59.615Z').toISOString(),
+            createdAt: new Date('2024-04-03T13:56:59.615Z'),
+            updatedAt: new Date('2024-04-03T13:56:59.615Z'),
+          },
+          {
+            transactionDatabaseId: transactionDatabaseId,
+            sampledValue: JSON.stringify([
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 347.0,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L1',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 116.0,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L2',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 116.0,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L3',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 116.0,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'L1',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 16.045677185058594,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'L2',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 16.045677185058594,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'L3',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 16.045677185058594,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'N',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 0.2005709707736969,
+              },
+            ]),
+            timestamp: new Date('2024-04-03T13:57:49.049Z').toISOString(),
+            createdAt: new Date('2024-04-03T13:57:49.049Z'),
+            updatedAt: new Date('2024-04-03T13:57:49.049Z'),
+          },
+          {
+            transactionDatabaseId: transactionDatabaseId,
+            sampledValue: JSON.stringify([
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 377.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L1',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 126.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L2',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 126.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L3',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 126.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Voltage',
+                phase: 'L1-N',
+                unitOfMeasure: {
+                  unit: 'V',
+                },
+                value: 222.17013549804688,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Voltage',
+                phase: 'L2-N',
+                unitOfMeasure: {
+                  unit: 'V',
+                },
+                value: 222.17013549804688,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Voltage',
+                phase: 'L3-N',
+                unitOfMeasure: {
+                  unit: 'V',
+                },
+                value: 222.17013549804688,
+              },
+            ]),
+            timestamp: new Date('2024-04-03T13:57:59.112Z').toISOString(),
+            createdAt: new Date('2024-04-03T13:57:59.112Z'),
+            updatedAt: new Date('2024-04-03T13:57:59.112Z'),
+          },
+          {
+            transactionDatabaseId: transactionDatabaseId,
+            sampledValue: JSON.stringify([
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 523.0,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L1',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 174.0,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L2',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 174.0,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L3',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 174.0,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'L1',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 15.886229515075684,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'L2',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 15.886229515075684,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'L3',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 15.886229515075684,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'N',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 0.1985778659582138,
+              },
+            ]),
+            timestamp: new Date('2024-04-03T13:58:48.549Z').toISOString(),
+            createdAt: new Date('2024-04-03T13:58:48.549Z'),
+            updatedAt: new Date('2024-04-03T13:58:48.549Z'),
+          },
+          {
+            transactionDatabaseId: transactionDatabaseId,
+            sampledValue: JSON.stringify([
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 556.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L1',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 185.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L2',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 185.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L3',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 185.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Voltage',
+                phase: 'L1-N',
+                unitOfMeasure: {
+                  unit: 'V',
+                },
+                value: 221.9342041015625,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Voltage',
+                phase: 'L2-N',
+                unitOfMeasure: {
+                  unit: 'V',
+                },
+                value: 221.9342041015625,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Voltage',
+                phase: 'L3-N',
+                unitOfMeasure: {
+                  unit: 'V',
+                },
+                value: 221.9342041015625,
+              },
+            ]),
+            timestamp: new Date('2024-04-03T13:58:59.632Z').toISOString(),
+            createdAt: new Date('2024-04-03T13:58:59.632Z'),
+            updatedAt: new Date('2024-04-03T13:58:59.632Z'),
+          },
+          {
+            transactionDatabaseId: transactionDatabaseId,
+            sampledValue: JSON.stringify([
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 702.0,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L1',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 234.0,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L2',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 234.0,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L3',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 234.0,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'L1',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 16.126832962036133,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'L2',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 16.126832962036133,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'L3',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 16.126832962036133,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'N',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 0.20158541202545166,
+              },
+            ]),
+            timestamp: new Date('2024-04-03T13:59:49.077Z').toISOString(),
+            createdAt: new Date('2024-04-03T13:59:49.077Z'),
+            updatedAt: new Date('2024-04-03T13:59:49.077Z'),
+          },
+          {
+            transactionDatabaseId: transactionDatabaseId,
+            sampledValue: JSON.stringify([
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 732.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L1',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 244.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L2',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 244.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L3',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 244.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Voltage',
+                phase: 'L1-N',
+                unitOfMeasure: {
+                  unit: 'V',
+                },
+                value: 222.07337951660156,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Voltage',
+                phase: 'L2-N',
+                unitOfMeasure: {
+                  unit: 'V',
+                },
+                value: 222.07337951660156,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Voltage',
+                phase: 'L3-N',
+                unitOfMeasure: {
+                  unit: 'V',
+                },
+                value: 222.07337951660156,
+              },
+            ]),
+            timestamp: new Date('2024-04-03T13:59:59.175Z').toISOString(),
+            createdAt: new Date('2024-04-03T13:59:59.175Z'),
+            updatedAt: new Date('2024-04-03T13:59:59.175Z'),
+          },
+          {
+            transactionDatabaseId: transactionDatabaseId,
+            sampledValue: JSON.stringify([
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 879.0,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L1',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 293.0,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L2',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 293.0,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L3',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 293.0,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'L1',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 16.023082733154297,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'L2',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 16.023082733154297,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'L3',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 16.023082733154297,
+              },
+              {
+                context: 'Sample.Periodic',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'N',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 0.2002885341644287,
+              },
+            ]),
+            timestamp: new Date('2024-04-03T14:00:48.657Z').toISOString(),
+            createdAt: new Date('2024-04-03T14:00:48.657Z'),
+            updatedAt: new Date('2024-04-03T14:00:48.657Z'),
+          },
+          {
+            transactionDatabaseId: transactionDatabaseId,
+            sampledValue: JSON.stringify([
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 911.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L1',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 304.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L2',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 304.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L3',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 304.0,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Voltage',
+                phase: 'L1-N',
+                unitOfMeasure: {
+                  unit: 'V',
+                },
+                value: 221.85638427734375,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Voltage',
+                phase: 'L2-N',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 221.85638427734375,
+              },
+              {
+                context: 'Sample.Clock',
+                location: 'Outlet',
+                measurand: 'Voltage',
+                phase: 'L3-N',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 221.85638427734375,
+              },
+            ]),
+            timestamp: new Date('2024-04-03T14:00:59.730Z').toISOString(),
+            createdAt: new Date('2024-04-03T14:00:59.730Z'),
+            updatedAt: new Date('2024-04-03T14:00:59.730Z'),
+          },
+          {
+            transactionDatabaseId: transactionDatabaseId,
+            sampledValue: JSON.stringify([
+              {
+                context: 'Transaction.End',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 980.0,
+              },
+              {
+                context: 'Transaction.End',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L1',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 327.0,
+              },
+              {
+                context: 'Transaction.End',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L2',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 327.0,
+              },
+              {
+                context: 'Transaction.End',
+                location: 'Outlet',
+                measurand: 'Energy.Active.Import.Register',
+                phase: 'L3',
+                unitOfMeasure: {
+                  unit: 'Wh',
+                },
+                value: 327.0,
+              },
+              {
+                context: 'Transaction.End',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'L1',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 15.879820823669434,
+              },
+              {
+                context: 'Transaction.End',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'L2',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 15.879820823669434,
+              },
+              {
+                context: 'Transaction.End',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'L3',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 15.879820823669434,
+              },
+              {
+                context: 'Transaction.End',
+                location: 'Outlet',
+                measurand: 'Current.Import',
+                phase: 'N',
+                unitOfMeasure: {
+                  unit: 'A',
+                },
+                value: 0.19849777221679688,
+              },
+            ]),
+            timestamp: new Date('2024-04-03T14:01:22.936Z').toISOString(),
+            createdAt: new Date('2024-04-03T14:01:22.936Z'),
+            updatedAt: new Date('2024-04-03T14:01:22.936Z'),
           },
         ],
         {},
@@ -221,9 +1198,8 @@ export = {
 
     try {
       const transaction = await createTransaction();
-      const transactionDatabaseId = (transaction as any).id;
-      await createTransactionEvents(transactionDatabaseId);
-      await createMeterValues(transactionDatabaseId);
+      await createTransactionEvents(transaction[0].id);
+      await createMeterValues(transaction[0].id);
 
       console.log('Transaction Data seeded successfully');
     } catch (error) {
@@ -270,52 +1246,6 @@ export = {
         },
         {},
       );
-
-      // Delete IdToken
-      await queryInterface.bulkDelete(
-        'IdTokens',
-        {
-          createdAt: new Date(0),
-        },
-        {},
-      );
-
-      // Delete EVSE
-      await queryInterface.bulkDelete(
-        'Evses',
-        {
-          createdAt: new Date(0),
-        },
-        {},
-      );
-
-      // Delete ChargingStation
-      await queryInterface.bulkDelete(
-        'ChargingStations',
-        {
-          createdAt: new Date(0),
-        },
-        {},
-      );
-
-      // Delete Location
-      await queryInterface.bulkDelete(
-        'Locations',
-        {
-          createdAt: new Date(0),
-        },
-        {},
-      );
-
-      // Delete OCPILocations
-      await queryInterface.bulkDelete(
-        'OcpiLocations',
-        {
-          createdAt: new Date(0),
-        },
-        {},
-      );
-
       console.log('Transaction data reverted successfully');
     } catch (error) {
       console.error('Error reverting Transactions data:', error);

--- a/seeders/20240703120234-transactions.ts
+++ b/seeders/20240703120234-transactions.ts
@@ -30,38 +30,6 @@ const DUMMY_IDS = {
 /** @type {import('sequelize-cli').Migration} */
 export = {
   up: async (queryInterface: QueryInterface) => {
-    const createEvses = async () => {
-      await queryInterface.bulkInsert(
-        'Evses',
-        [
-          {
-            databaseId: DUMMY_IDS.EVSE_ID,
-            id: DUMMY_IDS.EVSE_ID,
-            connectorId: 1,
-            createdAt: new Date(0),
-            updatedAt: new Date(),
-          },
-        ],
-        {},
-      );
-    };
-
-    const createIdToken = async () => {
-      await queryInterface.bulkInsert(
-        'IdTokens',
-        [
-          {
-            id: DUMMY_IDS.ID_TOKEN_ID,
-            idToken: DUMMY_IDS.ID_TOKEN,
-            type: IdTokenEnumType.eMAID,
-            createdAt: new Date(0),
-            updatedAt: new Date(),
-          },
-        ],
-        {},
-      );
-    };
-
     const createTransaction = async () =>
       await queryInterface.bulkInsert(
         'Transactions',
@@ -251,59 +219,7 @@ export = {
       );
     };
 
-    const createLocations = async () =>
-      await queryInterface.bulkInsert(
-        'Locations',
-        [
-          {
-            name: 'name',
-            address: 'address',
-            city: 'city',
-            postalCode: 'postalCode',
-            state: 'state',
-            country: 'country',
-            coordinates: Sequelize.fn('ST_GeomFromText', 'POINT(74 41)'), // converts to needed Geometry object
-            createdAt: new Date(0),
-            updatedAt: new Date(),
-          },
-        ],
-        {
-          returning: true,
-        } as QueryOptions,
-      );
-
-    const createOcpiLocations = async (location: any) => {
-      await queryInterface.bulkInsert('OcpiLocations', [
-        {
-          [OcpiLocationProps.citrineLocationId]: location.id,
-          [OcpiLocationProps.publish]: true,
-          [OcpiLocationProps.lastUpdated]: new Date(),
-          [OcpiLocationProps.partyId]: 'CPO',
-          [OcpiLocationProps.countryCode]: 'US',
-          createdAt: new Date(0),
-          updatedAt: new Date(),
-        },
-      ]);
-    };
-
-    const createChargingStation = async (location: any) => {
-      await queryInterface.bulkInsert('ChargingStations', [
-        {
-          id: DUMMY_IDS.CHARGING_STATION,
-          isOnline: true,
-          locationId: location.id,
-          createdAt: new Date(0),
-          updatedAt: new Date(),
-        },
-      ]);
-    };
-
     try {
-      const location = await createLocations();
-      await createOcpiLocations(location);
-      await createChargingStation(location);
-      await createEvses();
-      await createIdToken();
       const transaction = await createTransaction();
       const transactionDatabaseId = (transaction as any).id;
       await createTransactionEvents(transactionDatabaseId);


### PR DESCRIPTION
fix: adjusting session broadcaster to send PUT vs PATCH push to clients depending on whether the transactionRepository fires a 'created' or 'updated' event to ensure that it does not appear as a duplicate PUT
<img width="1373" alt="Screenshot 2024-07-16 at 12 40 34 PM" src="https://github.com/user-attachments/assets/06abc174-ea37-4fec-a820-5a72729dfc75">
<img width="1317" alt="Screenshot 2024-07-16 at 12 40 28 PM" src="https://github.com/user-attachments/assets/c123482f-6391-4ecb-b66b-ae4a66d702b4">
