### PR TITLE
Added admin api for fetching tokens

### DIFF
--- a/00_Base/src/index.ts
+++ b/00_Base/src/index.ts
@@ -177,7 +177,7 @@ export { LocationsClientApi } from './trigger/LocationsClientApi';
 export { CommandsService } from './services/commands.service';
 export { CredentialsService } from './services/credentials.service';
 export { TokensService } from './services/TokensService';
-export { TokensFetchService } from './services/TokensFetchService';
+export { TokensAdminService } from './services/TokensAdminService';
 export { LocationsService } from './services/locations.service';
 export { VersionService } from './services/version.service';
 export { AsyncJobStatusDTO } from './model/AsyncJobStatus';

--- a/00_Base/src/index.ts
+++ b/00_Base/src/index.ts
@@ -177,9 +177,12 @@ export { LocationsClientApi } from './trigger/LocationsClientApi';
 export { CommandsService } from './services/commands.service';
 export { CredentialsService } from './services/credentials.service';
 export { TokensService } from './services/TokensService';
+export { TokensFetchService } from './services/TokensFetchService';
 export { LocationsService } from './services/locations.service';
 export { VersionService } from './services/version.service';
 export { AsyncJobStatusDTO } from './model/AsyncJobStatus';
+export { AsyncJobAction } from './model/AsyncJobAction';
+export { AsyncJobRequest } from './model/AsyncJobRequest';
 export { SessionsService } from './services/sessions.service';
 
 export { TariffsService } from './services/tariffs.service';

--- a/00_Base/src/model/AsyncJobAction.ts
+++ b/00_Base/src/model/AsyncJobAction.ts
@@ -1,0 +1,4 @@
+export enum AsyncJobAction {
+  RESUME = 'RESUME',
+  STOP = 'STOP',
+}

--- a/00_Base/src/model/AsyncJobRequest.ts
+++ b/00_Base/src/model/AsyncJobRequest.ts
@@ -1,0 +1,9 @@
+import { PaginatedParams } from '../controllers/param/paginated.params';
+
+export class AsyncJobRequest {
+  mspCountryCode!: string;
+  mspPartyId!: string;
+  cpoCountryCode!: string;
+  cpoPartyId!: string;
+  paginatedParams!: PaginatedParams;
+}

--- a/00_Base/src/model/AsyncJobStatus.ts
+++ b/00_Base/src/model/AsyncJobStatus.ts
@@ -10,7 +10,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { PaginatedParams } from '../controllers/param/paginated.params';
 
 export enum AsyncJobName {
-  FETCH_OCPI_TOKENS = 'fetch OCPI tokens',
+  FETCH_OCPI_TOKENS = 'FETCH_OCPI_TOKENS',
 }
 
 @Table
@@ -23,55 +23,67 @@ export class AsyncJobStatus extends Model {
   @Column(DataType.ENUM(...Object.values(AsyncJobName)))
   jobName!: AsyncJobName;
 
-  @Default(false)
+  @Column(DataType.STRING)
+  mspCountryCode!: string;
+
+  @Column(DataType.STRING)
+  mspPartyId!: string;
+
+  @Column(DataType.STRING)
+  cpoCountryCode!: string;
+
+  @Column(DataType.STRING)
+  cpoPartyId!: string;
+
+  @Column(DataType.DATE)
+  finishedAt?: Date;
+
+  @Column(DataType.DATE)
+  stoppedAt?: Date | null;
+
   @Column(DataType.BOOLEAN)
-  isFinished!: boolean;
+  stopScheduled!: boolean;
 
-  @Column(DataType.STRING)
-  countryCode!: string;
-
-  @Column(DataType.STRING)
-  partyId!: string;
-
-  @Column(DataType.DATE) // Start Time is automatically set with the created at field
-  stopTime?: Date;
-
-  @Column(DataType.INTEGER) // Updated after first request is done and the response shows the pagination information
-  totalObjects?: number;
-
-  @Column(DataType.INTEGER) // Use to keep track of how far we are
-  currentOffset?: number;
+  @Column(DataType.BOOLEAN)
+  isFailed!: boolean;
 
   @Column(DataType.JSON)
-  paginatedParams?: PaginatedParams;
+  paginationParams!: PaginatedParams;
 
-  @Column(DataType.STRING)
-  failureMessage?: string; // Used to keep track of the errors. If this is set, it means something went wrong
+  @Column(DataType.INTEGER) // Total number of objects in the client's system
+  totalObjects?: number;
 
   toDTO(): AsyncJobStatusDTO {
     return {
       jobId: this.jobId,
+      jobName: this.jobName,
+      mspCountryCode: this.mspCountryCode,
+      mspPartyId: this.mspPartyId,
+      cpoCountryCode: this.cpoCountryCode,
+      cpoPartyId: this.cpoPartyId,
       createdAt: this.createdAt,
-      isFinished: this.isFinished,
-      stopTime: this.stopTime,
+      finishedAt: this.finishedAt,
+      stoppedAt: this.stoppedAt,
+      stopScheduled: this.stopScheduled,
+      isFailed: this.isFailed,
+      paginatedParams: this.paginationParams,
       totalObjects: this.totalObjects,
-      currentOffset: this.currentOffset,
-      paginatedParams: this.paginatedParams,
-      countryCode: this.countryCode,
-      partyId: this.partyId,
     };
   }
 }
 
 export class AsyncJobStatusDTO {
   jobId!: string;
+  jobName!: AsyncJobName;
+  mspCountryCode!: string;
+  mspPartyId!: string;
+  cpoCountryCode!: string;
+  cpoPartyId!: string;
   createdAt!: Date;
-  isFinished!: boolean;
-  stopTime?: Date;
+  finishedAt?: Date;
+  stoppedAt?: Date | null;
+  stopScheduled!: boolean;
+  isFailed?: boolean;
+  paginatedParams!: PaginatedParams;
   totalObjects?: number;
-  currentOffset?: number;
-  currentLimit?: number;
-  paginatedParams?: PaginatedParams;
-  countryCode!: string;
-  partyId!: string;
 }

--- a/00_Base/src/repository/AsyncJobStatus.ts
+++ b/00_Base/src/repository/AsyncJobStatus.ts
@@ -21,26 +21,24 @@ export class AsyncJobStatusRepository extends SequelizeRepository<AsyncJobStatus
     );
   }
 
-  async createOrUpdateAsyncJobStatus(
+  async createAsyncJobStatus(
     jobStatus: AsyncJobStatus,
   ): Promise<AsyncJobStatus> {
-    if (
-      !jobStatus.jobId ||
-      (await this.readAllByQuery({ where: { jobId: jobStatus.jobId } }))
-        .length === 0
-    ) {
-      return await this._create(jobStatus);
-    } else {
-      const updatedJobStatus = await this.updateByKey(
-        jobStatus.dataValues,
-        jobStatus.jobId,
+    return await this._create(jobStatus);
+  }
+
+  async updateAsyncJobStatus(
+    jobStatus: Partial<AsyncJobStatus>,
+  ): Promise<AsyncJobStatus> {
+    const updatedJobStatus = await this.updateByKey(
+      jobStatus,
+      jobStatus.jobId!,
+    );
+    if (!updatedJobStatus) {
+      throw new Error(
+        `Failed to update job status: AsyncJobStatus ${jobStatus.jobId} not found`,
       );
-      if (!updatedJobStatus) {
-        throw new Error(
-          `Failed to update job status: AsyncJobStatus ${jobStatus.jobId} not found`,
-        );
-      }
-      return updatedJobStatus;
     }
+    return updatedJobStatus;
   }
 }

--- a/00_Base/src/services/TokensAdminService.ts
+++ b/00_Base/src/services/TokensAdminService.ts
@@ -23,7 +23,7 @@ import { BadRequestError, NotFoundError } from 'routing-controllers';
 import { AsyncJobRequest } from '../model/AsyncJobRequest';
 
 @Service()
-export class TokensFetchService {
+export class TokensAdminService {
   constructor(
     private readonly logger: OcpiLogger,
     private readonly tokenRepository: TokensRepository,
@@ -93,7 +93,7 @@ export class TokensFetchService {
         asyncJobStatus.mspCountryCode,
         asyncJobStatus.mspPartyId,
         asyncJobStatus.cpoCountryCode,
-        Role.CPO,
+        asyncJobStatus.cpoPartyId,
         asyncJobStatus.paginationParams.offset,
         asyncJobStatus.paginationParams.limit,
         asyncJobStatus.paginationParams.dateFrom,

--- a/00_Base/src/services/TokensFetchService.ts
+++ b/00_Base/src/services/TokensFetchService.ts
@@ -1,0 +1,260 @@
+// Copyright (c) 2023 S44, LLC
+// Copyright Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache 2.0
+
+import { Service } from 'typedi';
+import { OcpiLogger } from '../util/logger';
+import { TokensRepository } from '../repository/TokensRepository';
+import { AsyncJobName, AsyncJobStatus } from '../model/AsyncJobStatus';
+import { TokensClientApi } from '../trigger/TokensClientApi';
+import { buildPaginatedOcpiParams } from '../trigger/param/paginated.ocpi.params';
+import { Role } from '../model/Role';
+import { AsyncJobStatusRepository } from '../repository/AsyncJobStatus';
+import { OcpiResponseStatusCode } from '../model/ocpi.response';
+import { UnsuccessfulRequestException } from '../exception/UnsuccessfulRequestException';
+import { CredentialsService } from './credentials.service';
+import {
+  ClientInformation,
+  ClientInformationProps,
+} from '../model/ClientInformation';
+import { Op } from 'sequelize';
+import { BadRequestError, NotFoundError } from 'routing-controllers';
+import { AsyncJobRequest } from '../model/AsyncJobRequest';
+
+@Service()
+export class TokensFetchService {
+  constructor(
+    private readonly logger: OcpiLogger,
+    private readonly tokenRepository: TokensRepository,
+    private readonly asyncJobStatusRepository: AsyncJobStatusRepository,
+    private readonly client: TokensClientApi,
+    private readonly credentialsService: CredentialsService,
+  ) {}
+
+  async startFetchTokensByParty(
+    asyncJobRequest: AsyncJobRequest,
+  ): Promise<AsyncJobStatus> {
+    const existingJob = await this.getFetchTokensJobs(
+      asyncJobRequest.mspCountryCode,
+      asyncJobRequest.mspPartyId,
+      asyncJobRequest.cpoCountryCode,
+      asyncJobRequest.cpoPartyId,
+      true,
+    );
+
+    if (existingJob && existingJob.length > 0) {
+      throw new UnsuccessfulRequestException(
+        `Another job for MSP ${asyncJobRequest.mspCountryCode}-${asyncJobRequest.mspPartyId} + CPO  ${asyncJobRequest.cpoCountryCode}-${asyncJobRequest.cpoPartyId} is already in progress with ID ${existingJob[0].jobId}`,
+      );
+    }
+
+    const clientCredentials =
+      await this.credentialsService.getClientInformationByClientCountryCodeAndPartyId(
+        asyncJobRequest.mspCountryCode,
+        asyncJobRequest.mspPartyId,
+      );
+
+    let asyncJobStatus: AsyncJobStatus | undefined = AsyncJobStatus.build({
+      jobName: AsyncJobName.FETCH_OCPI_TOKENS,
+      paginationParams: {
+        limit: asyncJobRequest.paginatedParams?.limit ?? 1000,
+        offset: asyncJobRequest.paginatedParams?.offset ?? 0,
+      },
+      mspCountryCode: asyncJobRequest.mspCountryCode,
+      mspPartyId: asyncJobRequest.mspPartyId,
+      cpoCountryCode: asyncJobRequest.cpoCountryCode,
+      cpoPartyId: asyncJobRequest.cpoPartyId,
+      isFailed: false,
+      stopScheduled: false,
+    });
+
+    asyncJobStatus =
+      await this.asyncJobStatusRepository.createAsyncJobStatus(asyncJobStatus);
+
+    this.fetchTokens(asyncJobStatus, clientCredentials);
+
+    return asyncJobStatus;
+  }
+
+  async fetchTokens(
+    asyncJobStatus: AsyncJobStatus,
+    clientCredentials: ClientInformation,
+  ) {
+    try {
+      const token = clientCredentials[ClientInformationProps.clientToken];
+      const clientVersions = await clientCredentials.$get(
+        ClientInformationProps.clientVersionDetails,
+      );
+
+      this.client.baseUrl = clientVersions[0].url;
+
+      const params = buildPaginatedOcpiParams(
+        asyncJobStatus.mspCountryCode,
+        asyncJobStatus.mspPartyId,
+        asyncJobStatus.cpoCountryCode,
+        Role.CPO,
+        asyncJobStatus.paginationParams.offset,
+        asyncJobStatus.paginationParams.limit,
+        asyncJobStatus.paginationParams.dateFrom,
+        asyncJobStatus.paginationParams.dateTo,
+      );
+      params.authorization = token;
+      params.version = clientVersions[0].version;
+
+      let finished = false;
+
+      do {
+        const response = await this.client.getTokens(params);
+        if (
+          response.status_code === OcpiResponseStatusCode.GenericSuccessCode
+        ) {
+          await this.tokenRepository.updateBatchedTokens(response.data);
+
+          asyncJobStatus =
+            await this.asyncJobStatusRepository.updateAsyncJobStatus({
+              jobId: asyncJobStatus.jobId,
+              paginationParams: {
+                limit: response.limit,
+                offset: response.offset
+                  ? response.offset
+                  : asyncJobStatus.paginationParams.offset,
+                dateFrom: asyncJobStatus.paginationParams.dateFrom,
+                dateTo: asyncJobStatus.paginationParams.dateTo,
+              },
+              totalObjects: response.total!,
+            });
+
+          if (asyncJobStatus.stopScheduled) {
+            finished = true;
+            break;
+          }
+
+          params.offset = response.offset;
+          params.limit = response.limit;
+
+          finished = !response.link;
+        } else {
+          this.logger.error(
+            'Received non-successful response from Tokens fetch for job ' +
+              asyncJobStatus.jobId,
+            response,
+          );
+          asyncJobStatus.isFailed = true;
+          break;
+        }
+      } while (!finished);
+    } catch (e) {
+      this.logger.error(
+        'Failed to fetch tokens for job ' + asyncJobStatus.jobId,
+        e,
+      );
+      asyncJobStatus.isFailed = true;
+    }
+
+    if (asyncJobStatus.stopScheduled) {
+      await this.asyncJobStatusRepository.updateAsyncJobStatus({
+        jobId: asyncJobStatus.jobId,
+        stoppedAt: new Date(),
+        isFailed: asyncJobStatus.isFailed,
+      });
+    } else {
+      await this.asyncJobStatusRepository.updateAsyncJobStatus({
+        jobId: asyncJobStatus.jobId,
+        finishedAt: new Date(),
+        isFailed: asyncJobStatus.isFailed,
+      });
+    }
+  }
+
+  async stopFetchTokens(jobId: string): Promise<AsyncJobStatus> {
+    let existingJob = await this.getFetchTokensJob(jobId);
+
+    if (!existingJob) {
+      throw new NotFoundError('Job not found');
+    }
+
+    if (existingJob.finishedAt) {
+      throw new BadRequestError('Job already finished');
+    }
+
+    existingJob = await this.asyncJobStatusRepository.updateAsyncJobStatus({
+      jobId: existingJob.jobId,
+      stopScheduled: true,
+    });
+
+    return existingJob;
+  }
+
+  async resumeFetchTokens(jobId: string): Promise<AsyncJobStatus> {
+    let existingJob = await this.getFetchTokensJob(jobId);
+
+    if (!existingJob) {
+      throw new NotFoundError('Job not found');
+    }
+
+    if (existingJob.finishedAt) {
+      throw new BadRequestError('Job already finished');
+    }
+
+    if (!existingJob.finishedAt && !existingJob.stoppedAt) {
+      throw new BadRequestError('Job already running');
+    }
+
+    const clientCredentials =
+      await this.credentialsService.getClientInformationByClientCountryCodeAndPartyId(
+        existingJob.mspCountryCode,
+        existingJob.mspPartyId,
+      );
+
+    existingJob = await this.asyncJobStatusRepository.updateAsyncJobStatus({
+      jobId: existingJob.jobId,
+      stopScheduled: false,
+      stoppedAt: null,
+    });
+
+    this.fetchTokens(existingJob, clientCredentials);
+
+    return existingJob;
+  }
+
+  async getFetchTokensJob(jobId: string): Promise<AsyncJobStatus | undefined> {
+    return await this.asyncJobStatusRepository.readByKey(jobId);
+  }
+
+  async getFetchTokensJobs(
+    mspCountryCode: string,
+    mspPartyId: string,
+    cpoCountryCode: string,
+    cpoPartyId: string,
+    active?: boolean,
+  ): Promise<AsyncJobStatus[]> {
+    const query: any = {
+      jobName: AsyncJobName.FETCH_OCPI_TOKENS,
+      mspCountryCode: mspCountryCode,
+      mspPartyId: mspPartyId,
+      cpoCountryCode: cpoCountryCode,
+      cpoPartyId: cpoPartyId,
+    };
+    if (active) {
+      query.finishedAt = { [Op.is]: null };
+      query.stoppedAt = { [Op.is]: null };
+    } else if (active === false) {
+      query[Op.or] = [
+        { finishedAt: { [Op.not]: null } },
+        { stoppedAt: { [Op.not]: null } },
+      ];
+    }
+    return await this.asyncJobStatusRepository.readAllByQuery({
+      where: {
+        ...query,
+      },
+    });
+  }
+
+  async deleteFetchTokensJob(
+    jobId: string,
+  ): Promise<AsyncJobStatus | undefined> {
+    return await this.asyncJobStatusRepository.deleteByKey(jobId);
+  }
+}

--- a/00_Base/src/services/TokensService.ts
+++ b/00_Base/src/services/TokensService.ts
@@ -7,17 +7,6 @@ import { Service } from 'typedi';
 import { SingleTokenRequest } from '../model/OcpiToken';
 import { OcpiLogger } from '../util/logger';
 import { TokensRepository } from '../repository/TokensRepository';
-import { PaginatedParams } from '../controllers/param/paginated.params';
-import { AsyncJobName, AsyncJobStatus } from '../model/AsyncJobStatus';
-import { TokensClientApi } from '../trigger/TokensClientApi';
-import { buildPaginatedOcpiParams } from '../trigger/param/paginated.ocpi.params';
-import { CountryCode } from '../util/util';
-import { Role } from '../model/Role';
-import { AsyncJobStatusRepository } from '../repository/AsyncJobStatus';
-import { OcpiResponseStatusCode } from '../model/ocpi.response';
-import { UnsuccessfulRequestException } from '../exception/UnsuccessfulRequestException';
-import { CredentialsService } from './credentials.service';
-import { ClientInformationProps } from '../model/ClientInformation';
 import { TokenDTO } from '../model/DTO/TokenDTO';
 
 @Service()
@@ -25,9 +14,6 @@ export class TokensService {
   constructor(
     private readonly logger: OcpiLogger,
     private readonly tokenRepository: TokensRepository,
-    private readonly asyncJobStatusRepository: AsyncJobStatusRepository,
-    private readonly client: TokensClientApi,
-    private readonly credentialsService: CredentialsService,
   ) {}
 
   async getSingleToken(
@@ -42,140 +28,5 @@ export class TokensService {
 
   async updateToken(token: TokenDTO): Promise<TokenDTO> {
     return this.tokenRepository.updateToken(token);
-  }
-
-  async startFetchTokensByParty(
-    countryCode: string,
-    partyId: string,
-    paginationParams?: PaginatedParams,
-  ): Promise<AsyncJobStatus> {
-    const existingJob = await this.asyncJobStatusRepository.readOnlyOneByQuery({
-      where: {
-        jobName: AsyncJobName.FETCH_OCPI_TOKENS,
-        countryCode: countryCode,
-        partyId: partyId,
-        isFinished: false,
-      },
-    });
-
-    if (existingJob) {
-      throw new UnsuccessfulRequestException(
-        `Another job for country ${countryCode} and party ${partyId} already in progress with Id ${existingJob.jobId}`,
-      );
-    }
-
-    let asyncJobStatus: AsyncJobStatus | undefined = AsyncJobStatus.build({
-      jobName: AsyncJobName.FETCH_OCPI_TOKENS,
-      paginationParams: paginationParams,
-      countryCode: countryCode,
-      partyId: partyId,
-    });
-
-    asyncJobStatus =
-      await this.asyncJobStatusRepository.createOrUpdateAsyncJobStatus(
-        asyncJobStatus,
-      );
-
-    this.fetchTokens(asyncJobStatus);
-
-    return asyncJobStatus;
-  }
-
-  async fetchTokens(asyncJobStatus: AsyncJobStatus) {
-    const retryLimit = 5;
-    // TODO spin off fetching tokens without waiting here
-
-    try {
-      const limit = asyncJobStatus.paginatedParams?.limit ?? 1000;
-      let offset = 0;
-      let retryCount = 5;
-      let totalTokensFetched = 0;
-      let batchTokens: TokenDTO[] | undefined;
-
-      const clientCredentials =
-        await this.credentialsService.getClientInformationByClientCountryCodeAndPartyId(
-          asyncJobStatus.countryCode,
-          asyncJobStatus.partyId,
-        );
-      const token = clientCredentials[ClientInformationProps.clientToken];
-      const clientVersions = await clientCredentials.$get(
-        ClientInformationProps.clientVersionDetails,
-      );
-
-      this.client.baseUrl = clientVersions[0].url;
-
-      let done = false;
-      do {
-        const params = buildPaginatedOcpiParams(
-          asyncJobStatus.countryCode,
-          asyncJobStatus.partyId,
-          CountryCode.US, // TODO fromCountryCode and fromPartyId should be configured centrally based on env config
-          Role.CPO,
-          offset,
-          limit,
-          asyncJobStatus.paginatedParams?.dateFrom,
-          asyncJobStatus.paginatedParams?.dateTo,
-        );
-        params.authorization = token;
-        params.version = clientVersions[0].version;
-
-        // TODO use actually next link
-        const response = await this.client.getTokens(params);
-        if (
-          response.status_code !== OcpiResponseStatusCode.GenericSuccessCode
-        ) {
-          retryCount--;
-        } else {
-          batchTokens = response.data;
-          try {
-            await this.tokenRepository.updateBatchedTokens(batchTokens);
-            asyncJobStatus.currentOffset = offset;
-            if (!asyncJobStatus.totalObjects) {
-              asyncJobStatus.totalObjects = response.total;
-            }
-            await this.asyncJobStatusRepository.createOrUpdateAsyncJobStatus(
-              asyncJobStatus,
-            );
-          } catch (e) {
-            this.logger.error(e);
-          }
-          totalTokensFetched += batchTokens.length;
-          retryCount = retryLimit;
-          offset += limit;
-        }
-
-        // TODO check if link to next page exists here instead of limit
-        if (
-          retryCount === 0 ||
-          (batchTokens && totalTokensFetched >= asyncJobStatus.totalObjects!)
-        ) {
-          done = true;
-        }
-      } while (!done);
-
-      asyncJobStatus.stopTime = new Date();
-      asyncJobStatus.totalObjects = totalTokensFetched;
-      asyncJobStatus.isFinished = true;
-      this.asyncJobStatusRepository.createOrUpdateAsyncJobStatus(
-        asyncJobStatus,
-      );
-      return asyncJobStatus;
-    } catch (e) {
-      this.logger.error(e);
-
-      asyncJobStatus.failureMessage = JSON.stringify(e);
-      asyncJobStatus.isFinished = true;
-      await this.asyncJobStatusRepository.createOrUpdateAsyncJobStatus(
-        asyncJobStatus,
-      );
-
-      throw new UnsuccessfulRequestException(
-        `Could not fetch tokens. Error ${e}`,
-      );
-    }
-  }
-
-  async getFetchTokensJob(jobId: string): Promise<AsyncJobStatus | undefined> {
-    return await this.asyncJobStatusRepository.readByKey(jobId);
   }
 }

--- a/00_Base/src/trigger/TokensClientApi.ts
+++ b/00_Base/src/trigger/TokensClientApi.ts
@@ -44,10 +44,7 @@ export class TokensClientApi extends BaseClientApi {
       options.queryParameters = queryParameters;
     }
 
-    return await this.get(PaginatedTokenResponse, {
-      version: params.version,
-      additionalHeaders,
-    });
+    return await this.get(PaginatedTokenResponse, options);
   }
 
   async postToken(params: PostTokenParams): Promise<AuthorizationInfoResponse> {

--- a/03_Modules/Tokens/src/module/api.ts
+++ b/03_Modules/Tokens/src/module/api.ts
@@ -38,7 +38,7 @@ import {
   TokenDTO,
   TokenResponse,
   TokensService,
-  TokensFetchService,
+  TokensAdminService,
   TokenType,
   UnknownTokenException,
   versionIdParam,
@@ -78,7 +78,7 @@ export class TokensModuleApi
 {
   constructor(
     readonly tokensService: TokensService,
-    readonly tokensFetchService: TokensFetchService,
+    readonly tokensFetchService: TokensAdminService,
   ) {
     super();
   }
@@ -250,7 +250,7 @@ export class TokensModuleApi
       success: generateMockOcpiResponse(AsyncJobStatusDTO),
     },
   })
-  async fetchTokensContinue(
+  async fetchTokensAction(
     @VersionNumberParam() version: VersionNumber,
     @Param('jobId') jobId: string,
     @Param('action') action: AsyncJobAction,

--- a/03_Modules/Tokens/src/module/api.ts
+++ b/03_Modules/Tokens/src/module/api.ts
@@ -12,12 +12,16 @@ import {
   Patch,
   Post,
   Put,
+  QueryParam,
+  BadRequestError,
+  Delete,
 } from 'routing-controllers';
 import { Service } from 'typedi';
 
 import { HttpStatus } from '@citrineos/base';
 import {
   AsOcpiFunctionalEndpoint,
+  AsyncJobAction,
   AsyncJobStatusDTO,
   BaseController,
   BodyWithExample,
@@ -29,13 +33,12 @@ import {
   OcpiEmptyResponse,
   OcpiHeaders,
   OcpiResponseStatusCode,
-  Paginated,
-  PaginatedParams,
   ResponseSchema,
   SingleTokenRequest,
   TokenDTO,
   TokenResponse,
   TokensService,
+  TokensFetchService,
   TokenType,
   UnknownTokenException,
   versionIdParam,
@@ -43,6 +46,7 @@ import {
   VersionNumberParam,
   WhitelistType,
   WrongClientAccessException,
+  AsyncJobRequest,
 } from '@citrineos/ocpi-base';
 import { ITokensModuleApi } from './interface';
 
@@ -72,7 +76,10 @@ export class TokensModuleApi
   extends BaseController
   implements ITokensModuleApi
 {
-  constructor(readonly tokensService: TokensService) {
+  constructor(
+    readonly tokensService: TokensService,
+    readonly tokensFetchService: TokensFetchService,
+  ) {
     super();
   }
 
@@ -219,8 +226,7 @@ export class TokensModuleApi
   /**
    * Admin Endpoints
    **/
-
-  @Post('/:countryCode/:partyId/fetch')
+  @Post('/fetch')
   @ResponseSchema(AsyncJobStatusDTO, {
     statusCode: HttpStatus.OK,
     description: 'Successful response',
@@ -230,19 +236,35 @@ export class TokensModuleApi
   })
   async fetchTokens(
     @VersionNumberParam() version: VersionNumber,
-    @Param('countryCode') countryCode: string,
-    @Param('partyId') partyId: string,
-    @Paginated() paginationParams?: PaginatedParams,
+    @Body() asyncJobRequest: AsyncJobRequest,
   ): Promise<AsyncJobStatusDTO> {
-    const jobStatus = await this.tokensService.startFetchTokensByParty(
-      countryCode,
-      partyId,
-      paginationParams,
-    );
+    const jobStatus =
+      await this.tokensFetchService.startFetchTokensByParty(asyncJobRequest);
     return jobStatus.toDTO();
   }
-
-  @Get('/:countryCode/:partyId/fetch/:jobId')
+  @Post('/fetch/:jobId/:action')
+  @ResponseSchema(AsyncJobStatusDTO, {
+    statusCode: HttpStatus.OK,
+    description: 'Successful response',
+    examples: {
+      success: generateMockOcpiResponse(AsyncJobStatusDTO),
+    },
+  })
+  async fetchTokensContinue(
+    @VersionNumberParam() version: VersionNumber,
+    @Param('jobId') jobId: string,
+    @Param('action') action: AsyncJobAction,
+  ): Promise<AsyncJobStatusDTO> {
+    switch (action) {
+      case AsyncJobAction.RESUME:
+        return (await this.tokensFetchService.resumeFetchTokens(jobId)).toDTO();
+      case AsyncJobAction.STOP:
+        return (await this.tokensFetchService.stopFetchTokens(jobId)).toDTO();
+      default:
+        throw new BadRequestError('Action not found');
+    }
+  }
+  @Get('/fetch/:jobId')
   @ResponseSchema(AsyncJobStatusDTO, {
     statusCode: HttpStatus.OK,
     description: 'Successful response',
@@ -252,12 +274,55 @@ export class TokensModuleApi
   })
   async getFetchTokensJobStatus(
     @VersionNumberParam() version: VersionNumber,
-    @Param('countryCode') countryCode: string,
-    @Param('partyId') partyId: string,
     @Param('jobId') jobId: string,
   ): Promise<AsyncJobStatusDTO> {
-    console.log('fetchTokens', countryCode, partyId, jobId);
-    const jobStatus = await this.tokensService.getFetchTokensJob(jobId);
+    const jobStatus = await this.tokensFetchService.getFetchTokensJob(jobId);
+    if (!jobStatus) {
+      throw new NotFoundError('Job not found');
+    }
+    return jobStatus.toDTO();
+  }
+
+  @Get('/fetch')
+  @ResponseSchema(AsyncJobStatusDTO, {
+    statusCode: HttpStatus.OK,
+    description: 'Successful response',
+    examples: {
+      success: generateMockOcpiResponse(AsyncJobStatusDTO),
+    },
+  })
+  async getActiveFetchTokensJobStatus(
+    @VersionNumberParam() version: VersionNumber,
+    @QueryParam('mspCountryCode') mspCountryCode: string,
+    @QueryParam('mspPartyId') mspPartyId: string,
+    @QueryParam('cpoCountryCode') cpoCountryCode: string,
+    @QueryParam('cpoPartyId') cpoPartyId: string,
+    @QueryParam('active', { required: false }) active: boolean,
+  ): Promise<AsyncJobStatusDTO[]> {
+    return (
+      await this.tokensFetchService.getFetchTokensJobs(
+        mspCountryCode,
+        mspPartyId,
+        cpoCountryCode,
+        cpoPartyId,
+        active,
+      )
+    ).map((job) => job.toDTO());
+  }
+
+  @Delete('/fetch/:jobId')
+  @ResponseSchema(AsyncJobStatusDTO, {
+    statusCode: HttpStatus.OK,
+    description: 'Successful response',
+    examples: {
+      success: generateMockOcpiResponse(AsyncJobStatusDTO),
+    },
+  })
+  async deleteFetchTokensJobStatus(
+    @VersionNumberParam() version: VersionNumber,
+    @Param('jobId') jobId: string,
+  ): Promise<AsyncJobStatusDTO> {
+    const jobStatus = await this.tokensFetchService.deleteFetchTokensJob(jobId);
     if (!jobStatus) {
       throw new NotFoundError('Job not found');
     }

--- a/Server/package.json
+++ b/Server/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "compile": "npm run clean && tsc -p tsconfig.json",
     "clean": "rm -rf dist/* tsconfig.tsbuildinfo",
-    "start": "export NODE_DEBUG=http && export APP_ENV=local && nodemon src/index.ts",
+    "start": "export APP_ENV=local && nodemon src/index.ts",
     "start-windows": "set APP_ENV=local && nodemon src/index.ts",
     "test": "../node_modules/.bin/jest --config jest.config.js",
     "init-db": "../node_modules/.bin/sequelize-cli db:migrate && sequelize-cli db:migrate:schema:timestamps:add",

--- a/mock-client/tokens.ts
+++ b/mock-client/tokens.ts
@@ -15,13 +15,17 @@ import {
   TokenType,
 } from '@citrineos/ocpi-base';
 import { HttpStatus } from '@citrineos/base';
-import { buildGenericServerErrorResponse } from '@citrineos/ocpi-base/dist/util/ResponseGenerator';
+import { ResponseGenerator } from '@citrineos/ocpi-base';
 
 const TOKENS_LIST_MOCK = generateMockOcpiResponse(PaginatedTokenResponse); // todo create real mocks for tests
 
 @JsonController(`/2.2.1/${ModuleId.Tokens}`)
 @Service()
 export class TokensController extends BaseController {
+  DEFAULT_TOTAL_OBJECTS = 10;
+  DEFAULT_LIMIT = 1;
+  RETURN_ERROR = false;
+
   constructor() {
     super();
   }
@@ -39,23 +43,21 @@ export class TokensController extends BaseController {
   ): Promise<OcpiResponse<TokenDTO>> {
     console.log(_paginationParams);
 
-    const fail = false;
-
-    if (fail) {
-      return buildGenericServerErrorResponse();
+    if (this.RETURN_ERROR) {
+      return ResponseGenerator.buildGenericServerErrorResponse();
     }
 
     const token = generateMockOcpiResponse(TokenDTO);
 
-    token.uid = (2 + (_paginationParams?.offset ?? 0)).toString();
+    token.uid = (2 + (_paginationParams?.offset ?? 0)).toString(); // Avoid collision with Token UID 1 which is seeded.
     token.country_code = 'US';
     token.party_id = 'MSP';
     token.type = TokenType.APP_USER;
 
     const response = buildOcpiPaginatedResponse(
       OcpiResponseStatusCode.GenericSuccessCode,
-      10,
-      1,
+      this.DEFAULT_TOTAL_OBJECTS,
+      this.DEFAULT_LIMIT,
       _paginationParams?.offset ?? 0,
       [token],
     ) as OcpiResponse<TokenDTO>;

--- a/mock-client/tokens.ts
+++ b/mock-client/tokens.ts
@@ -5,14 +5,17 @@ import {
   buildOcpiPaginatedResponse,
   generateMockOcpiResponse,
   ModuleId,
+  OcpiResponse,
   OcpiResponseStatusCode,
   Paginated,
   PaginatedParams,
   PaginatedTokenResponse,
   ResponseSchema,
   TokenDTO,
+  TokenType,
 } from '@citrineos/ocpi-base';
 import { HttpStatus } from '@citrineos/base';
+import { buildGenericServerErrorResponse } from '@citrineos/ocpi-base/dist/util/ResponseGenerator';
 
 const TOKENS_LIST_MOCK = generateMockOcpiResponse(PaginatedTokenResponse); // todo create real mocks for tests
 
@@ -33,14 +36,32 @@ export class TokensController extends BaseController {
   })
   async getTokens(
     @Paginated() _paginationParams?: PaginatedParams,
-  ): Promise<PaginatedTokenResponse> {
+  ): Promise<OcpiResponse<TokenDTO>> {
+    console.log(_paginationParams);
+
+    const fail = false;
+
+    if (fail) {
+      return buildGenericServerErrorResponse();
+    }
+
+    const token = generateMockOcpiResponse(TokenDTO);
+
+    token.uid = (2 + (_paginationParams?.offset ?? 0)).toString();
+    token.country_code = 'US';
+    token.party_id = 'MSP';
+    token.type = TokenType.APP_USER;
+
     const response = buildOcpiPaginatedResponse(
       OcpiResponseStatusCode.GenericSuccessCode,
       10,
       1,
-      0,
-      [generateMockOcpiResponse(TokenDTO)],
-    ) as PaginatedTokenResponse;
+      _paginationParams?.offset ?? 0,
+      [token],
+    ) as OcpiResponse<TokenDTO>;
+
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
     return response;
   }
 }


### PR DESCRIPTION
Added new admin endpoints to update tokens a CPO has stored.

New endpoints added:
```
POST /ocpi/2.2.1/tokens/fetch <- start fetch
POST /ocpi/2.2.1/tokens/fetch/{jobId}/RESUME <- resume a stopped fetch
POST /ocpi/2.2.1/tokens/fetch/{jobId}/STOP <- stop an active fetch
GET /ocpi/2.2.1/tokens/fetch/{jobId} <- get a fetch by id
GET /ocpi/2.2.1/tokens/fetch?active&mspCountryCode&mspPartyId&cpoCountryCode&cpoPartyId <- get fetches
DELETE /ocpi/2.2.1/tokens/fetch/{jobId} <- delete fetch by id
```