### PR TITLE
HTTP Exception Handler for Admin Endpoints

### DIFF
--- a/00_Base/src/index.ts
+++ b/00_Base/src/index.ts
@@ -148,7 +148,7 @@ export { WrongClientAccessException } from './exception/wrong.client.access.exce
 export { LoggingMiddleware } from './util/middleware/logging.middleware';
 export { ChargingProfilesService } from './services/charging.profiles.service';
 export { AsyncResponder } from './util/AsyncResponder';
-export { AsOcpiAdminEndpoint } from './util/decorators/as.ocpi.admin.endpoint';
+export { AsAdminEndpoint } from './util/decorators/as.admin.endpoint';
 
 export { MessageSenderWrapper } from './util/MessageSenderWrapper';
 export { MessageHandlerWrapper } from './util/MessageHandlerWrapper';

--- a/00_Base/src/index.ts
+++ b/00_Base/src/index.ts
@@ -1,7 +1,6 @@
 import { RoutingControllersOptions, useContainer } from 'routing-controllers';
 import { Constructable, Container } from 'typedi';
 import { OcpiModule } from './model/OcpiModule';
-import { GlobalExceptionHandler } from './util/middleware/global.exception.handler';
 import { LoggingMiddleware } from './util/middleware/logging.middleware';
 import { OcpiServerConfig } from './config/ocpi.server.config';
 import { OcpiSequelizeInstance } from './util/sequelize';
@@ -141,7 +140,7 @@ export { OcpiHeaders } from './model/OcpiHeaders';
 export { AuthToken } from './util/decorators//auth.token';
 export { VersionNumberParam } from './util/decorators/version.number.param';
 export { EnumParam } from './util/decorators/enum.param';
-export { GlobalExceptionHandler } from './util/middleware/global.exception.handler';
+export { OcpiExceptionHandler } from './util/middleware/ocpi.exception.handler';
 export { InvalidParamException } from './exception/invalid.param.exception';
 export { MissingParamException } from './exception/missing.param.exception';
 export { UnknownTokenException } from './exception/unknown.token.exception';
@@ -149,6 +148,7 @@ export { WrongClientAccessException } from './exception/wrong.client.access.exce
 export { LoggingMiddleware } from './util/middleware/logging.middleware';
 export { ChargingProfilesService } from './services/charging.profiles.service';
 export { AsyncResponder } from './util/AsyncResponder';
+export { AsOcpiAdminEndpoint } from './util/decorators/as.ocpi.admin.endpoint';
 
 export { MessageSenderWrapper } from './util/MessageSenderWrapper';
 export { MessageHandlerWrapper } from './util/MessageHandlerWrapper';
@@ -255,7 +255,7 @@ export class OcpiServer extends KoaServer {
           ChargingProfilesController,
         ],
         routePrefix: '/ocpi',
-        middlewares: [GlobalExceptionHandler, LoggingMiddleware],
+        middlewares: [LoggingMiddleware],
         defaultErrorHandler: false,
       } as RoutingControllersOptions;
       this.initApp(options);

--- a/00_Base/src/util/decorators/as.admin.endpoint.ts
+++ b/00_Base/src/util/decorators/as.admin.endpoint.ts
@@ -9,7 +9,7 @@ import { HttpExceptionHandler } from '../middleware/http.exception.handler';
 /**
  * Decorator to add necessary auth and exception handling for "admin" OCPI endpoints
  */
-export const AsOcpiAdminEndpoint = function () {
+export const AsAdminEndpoint = function () {
   // TODO add auth as required
 
   return function (object: any, methodName: string) {

--- a/00_Base/src/util/decorators/as.ocpi.admin.endpoint.ts
+++ b/00_Base/src/util/decorators/as.ocpi.admin.endpoint.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2023 S44, LLC
+// Copyright Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache 2.0
+
+import { UseBefore } from 'routing-controllers';
+import { HttpExceptionHandler } from '../middleware/http.exception.handler';
+
+/**
+ * Decorator to add necessary auth and exception handling for "admin" OCPI endpoints
+ */
+export const AsOcpiAdminEndpoint = function () {
+  // TODO add auth as required
+
+  return function (object: any, methodName: string) {
+    UseBefore(HttpExceptionHandler)(object, methodName);
+  };
+};

--- a/00_Base/src/util/decorators/as.ocpi.functional.endpoint.ts
+++ b/00_Base/src/util/decorators/as.ocpi.functional.endpoint.ts
@@ -10,6 +10,7 @@ import { OcpiHttpHeader } from '../ocpi.http.header';
 import { OcpiHeaderMiddleware } from '../middleware/ocpi.header.middleware';
 import { UniqueMessageIdsMiddleware } from '../middleware/unique.message.ids.middleware';
 import { HttpHeader } from '@citrineos/base';
+import { OcpiExceptionHandler } from '../middleware/ocpi.exception.handler';
 
 export const uniqueMessageIdHeaders = {
   [OcpiHttpHeader.XRequestId]: { required: true },
@@ -36,5 +37,6 @@ export const AsOcpiFunctionalEndpoint = function () {
     UseBefore(AuthMiddleware)(object, methodName);
     UseBefore(OcpiHeaderMiddleware)(object, methodName);
     UseBefore(UniqueMessageIdsMiddleware)(object, methodName);
+    UseBefore(OcpiExceptionHandler)(object, methodName);
   };
 };

--- a/00_Base/src/util/decorators/as.ocpi.registration.endpoint.ts
+++ b/00_Base/src/util/decorators/as.ocpi.registration.endpoint.ts
@@ -9,6 +9,7 @@ import { AuthMiddleware } from '../middleware/auth.middleware';
 import { UniqueMessageIdsMiddleware } from '../middleware/unique.message.ids.middleware';
 import { HttpHeader } from '@citrineos/base';
 import { uniqueMessageIdHeaders } from './as.ocpi.functional.endpoint';
+import { OcpiExceptionHandler } from '../middleware/ocpi.exception.handler';
 
 function applyHeaders(headers: { [key: string]: ParamOptions }) {
   return function (object: any, methodName: string) {
@@ -17,6 +18,7 @@ function applyHeaders(headers: { [key: string]: ParamOptions }) {
     }
     UseBefore(AuthMiddleware)(object, methodName);
     UseBefore(UniqueMessageIdsMiddleware)(object, methodName);
+    UseBefore(OcpiExceptionHandler)(object, methodName);
   };
 }
 

--- a/00_Base/src/util/middleware/http.exception.handler.ts
+++ b/00_Base/src/util/middleware/http.exception.handler.ts
@@ -34,8 +34,6 @@ export class HttpExceptionHandler implements KoaMiddlewareInterface {
     try {
       await next();
     } catch (err) {
-      // TODO return a "custom" http object
-
       console.error('HttpExceptionHandler error', err);
       if (err?.constructor?.name) {
         switch (err.constructor.name) {

--- a/00_Base/src/util/middleware/http.exception.handler.ts
+++ b/00_Base/src/util/middleware/http.exception.handler.ts
@@ -1,0 +1,96 @@
+import { KoaMiddlewareInterface, Middleware, NotFoundError, UnauthorizedError } from 'routing-controllers';
+import { Context } from 'vm';
+import { Service } from 'typedi';
+import { HttpStatus } from '@citrineos/base';
+import { MissingParamException } from '../../exception/missing.param.exception';
+import { AlreadyRegisteredException } from '../../exception/AlreadyRegisteredException';
+import { NotRegisteredException } from '../../exception/NotRegisteredException';
+import { UnknownTokenException } from '../../exception/unknown.token.exception';
+import { WrongClientAccessException } from '../../exception/wrong.client.access.exception';
+import { InvalidParamException } from '../../exception/invalid.param.exception';
+import { UnsuccessfulRequestException } from '../../exception/UnsuccessfulRequestException';
+
+@Middleware({ type: 'before', priority: 10 })
+@Service()
+export class HttpExceptionHandler implements KoaMiddlewareInterface {
+  public async use(
+      context: Context,
+      next: (err?: any) => Promise<any>,
+  ): Promise<any> {
+      try {
+        await next();
+      } catch (err) {
+        // TODO return a "custom" http object
+
+        console.error('HttpExceptionHandler error', err);
+        if (err?.constructor?.name) {
+          switch (err.constructor.name) {
+            case UnauthorizedError.name:
+              context.status = HttpStatus.UNAUTHORIZED;
+              context.body = JSON.stringify(
+                new HttpExceptionBody('Not Authorized')
+              );
+              break;
+            case NotFoundError.name:
+              context.status = HttpStatus.NOT_FOUND;
+              context.body = JSON.stringify(
+                new HttpExceptionBody('Credentials not found')
+              );
+              break;
+            case MissingParamException.name:
+              context.status = HttpStatus.BAD_REQUEST;
+              context.body = JSON.stringify(
+                new HttpExceptionBody((err as any).message)
+              );
+              break;
+            case AlreadyRegisteredException.name:
+              context.status = HttpStatus.METHOD_NOT_ALLOWED;
+              context.body = JSON.stringify(
+                new HttpExceptionBody('Client already registered')
+              );
+              break;
+            case NotRegisteredException.name:
+              context.status = HttpStatus.METHOD_NOT_ALLOWED;
+              context.body = JSON.stringify(
+                new HttpExceptionBody('Client not registered')
+              );
+              break;
+            case UnknownTokenException.name:
+              context.status = HttpStatus.NOT_FOUND;
+              context.body = JSON.stringify(
+                new HttpExceptionBody((err as any).message)
+              );
+              break;
+            case WrongClientAccessException.name:
+              context.status = HttpStatus.NOT_FOUND;
+              break;
+            case InvalidParamException.name:
+              context.status = HttpStatus.BAD_REQUEST;
+              context.body = JSON.stringify(
+                new HttpExceptionBody((err as any).message)
+              );
+              break;
+            case UnsuccessfulRequestException.name:
+              context.status = HttpStatus.BAD_REQUEST;
+              context.body = JSON.stringify(
+                new HttpExceptionBody((err as any).message)
+              );
+              break;
+            default:
+              context.status = HttpStatus.INTERNAL_SERVER_ERROR;
+              context.body = JSON.stringify(
+                new HttpExceptionBody(`Internal Server Error, ${(err as Error).message}: ${JSON.stringify((err as any).errors)}`)
+              );
+          }
+        }
+      }
+  }
+}
+
+class HttpExceptionBody {
+  message?: string;
+
+  constructor(message?: string) {
+    this.message = message;
+  }
+}

--- a/00_Base/src/util/middleware/http.exception.handler.ts
+++ b/00_Base/src/util/middleware/http.exception.handler.ts
@@ -1,4 +1,9 @@
-import { KoaMiddlewareInterface, Middleware, NotFoundError, UnauthorizedError } from 'routing-controllers';
+import {
+  KoaMiddlewareInterface,
+  Middleware,
+  NotFoundError,
+  UnauthorizedError,
+} from 'routing-controllers';
 import { Context } from 'vm';
 import { Service } from 'typedi';
 import { HttpStatus, UnauthorizedException } from '@citrineos/base';
@@ -11,90 +16,91 @@ import { InvalidParamException } from '../../exception/invalid.param.exception';
 import { UnsuccessfulRequestException } from '../../exception/UnsuccessfulRequestException';
 import { NotFoundException } from '../../exception/NotFoundException';
 
-@Middleware({ type: 'before', priority: 10 })
-@Service()
-export class HttpExceptionHandler implements KoaMiddlewareInterface {
-  public async use(
-      context: Context,
-      next: (err?: any) => Promise<any>,
-  ): Promise<any> {
-      try {
-        await next();
-      } catch (err) {
-        // TODO return a "custom" http object
-
-        console.error('HttpExceptionHandler error', err);
-        if (err?.constructor?.name) {
-          switch (err.constructor.name) {
-            case UnauthorizedError.name:
-            case UnauthorizedException.name:
-              context.status = HttpStatus.UNAUTHORIZED;
-              context.body = JSON.stringify(
-                new HttpExceptionBody('Not Authorized')
-              );
-              break;
-            case NotFoundError.name:
-            case NotFoundException.name:
-              context.status = HttpStatus.NOT_FOUND;
-              context.body = JSON.stringify(
-                new HttpExceptionBody((err as any).message)
-              );
-              break;
-            case MissingParamException.name:
-              context.status = HttpStatus.BAD_REQUEST;
-              context.body = JSON.stringify(
-                new HttpExceptionBody((err as any).message)
-              );
-              break;
-            case AlreadyRegisteredException.name:
-              context.status = HttpStatus.METHOD_NOT_ALLOWED;
-              context.body = JSON.stringify(
-                new HttpExceptionBody('Client already registered')
-              );
-              break;
-            case NotRegisteredException.name:
-              context.status = HttpStatus.METHOD_NOT_ALLOWED;
-              context.body = JSON.stringify(
-                new HttpExceptionBody('Client not registered')
-              );
-              break;
-            case UnknownTokenException.name:
-              context.status = HttpStatus.NOT_FOUND;
-              context.body = JSON.stringify(
-                new HttpExceptionBody((err as any).message)
-              );
-              break;
-            case WrongClientAccessException.name:
-              context.status = HttpStatus.NOT_FOUND;
-              break;
-            case InvalidParamException.name:
-              context.status = HttpStatus.BAD_REQUEST;
-              context.body = JSON.stringify(
-                new HttpExceptionBody((err as any).message)
-              );
-              break;
-            case UnsuccessfulRequestException.name:
-              context.status = HttpStatus.BAD_REQUEST;
-              context.body = JSON.stringify(
-                new HttpExceptionBody((err as any).message)
-              );
-              break;
-            default:
-              const errors = (err as any).errors;
-              context.status = HttpStatus.INTERNAL_SERVER_ERROR;
-              context.body = JSON.stringify(
-                new HttpExceptionBody(`Internal Server Error, ${(err as Error).message}${errors ? ': ' + JSON.stringify(errors) : ''}`)
-              );
-          }
-        }
-      }
-  }
-}
-
 class HttpExceptionBody {
   message?: string;
 
   constructor(message?: string) {
     this.message = message;
+  }
+}
+
+@Middleware({ type: 'before', priority: 10 })
+@Service()
+export class HttpExceptionHandler implements KoaMiddlewareInterface {
+  public async use(
+    context: Context,
+    next: (err?: any) => Promise<any>,
+  ): Promise<any> {
+    try {
+      await next();
+    } catch (err) {
+      // TODO return a "custom" http object
+
+      console.error('HttpExceptionHandler error', err);
+      if (err?.constructor?.name) {
+        switch (err.constructor.name) {
+          case UnauthorizedError.name:
+          case UnauthorizedException.name:
+            context.status = HttpStatus.UNAUTHORIZED;
+            context.body = JSON.stringify(
+              new HttpExceptionBody('Not Authorized'),
+            );
+            break;
+          case NotFoundError.name:
+          case NotFoundException.name:
+            context.status = HttpStatus.NOT_FOUND;
+            context.body = JSON.stringify(
+              new HttpExceptionBody((err as any).message),
+            );
+            break;
+          case MissingParamException.name:
+            context.status = HttpStatus.BAD_REQUEST;
+            context.body = JSON.stringify(
+              new HttpExceptionBody((err as any).message),
+            );
+            break;
+          case AlreadyRegisteredException.name:
+            context.status = HttpStatus.METHOD_NOT_ALLOWED;
+            context.body = JSON.stringify(
+              new HttpExceptionBody('Client already registered'),
+            );
+            break;
+          case NotRegisteredException.name:
+            context.status = HttpStatus.METHOD_NOT_ALLOWED;
+            context.body = JSON.stringify(
+              new HttpExceptionBody('Client not registered'),
+            );
+            break;
+          case UnknownTokenException.name:
+            context.status = HttpStatus.NOT_FOUND;
+            context.body = JSON.stringify(
+              new HttpExceptionBody((err as any).message),
+            );
+            break;
+          case WrongClientAccessException.name:
+            context.status = HttpStatus.NOT_FOUND;
+            break;
+          case InvalidParamException.name:
+            context.status = HttpStatus.BAD_REQUEST;
+            context.body = JSON.stringify(
+              new HttpExceptionBody((err as any).message),
+            );
+            break;
+          case UnsuccessfulRequestException.name:
+            context.status = HttpStatus.BAD_REQUEST;
+            context.body = JSON.stringify(
+              new HttpExceptionBody((err as any).message),
+            );
+            break;
+          default:
+            context.status = HttpStatus.INTERNAL_SERVER_ERROR;
+            context.body = JSON.stringify(
+              new HttpExceptionBody(
+                `Internal Server Error, ${(err as Error).message}${(err as any).errors ? ': ' + JSON.stringify((err as any).errors) : ''}`,
+              ),
+            );
+        }
+      }
+    }
   }
 }

--- a/00_Base/src/util/middleware/logging.middleware.ts
+++ b/00_Base/src/util/middleware/logging.middleware.ts
@@ -10,7 +10,7 @@ export class LoggingMiddleware implements KoaMiddlewareInterface {
     context: Context,
     next: (err?: any) => Promise<any>,
   ): Promise<any> {
-    console.log(`Received request: ${context.request}`);
+    console.debug(`Received context: ${JSON.stringify(context)}`);
     return next()
       .then(() => {
         console.debug('do something after execution');

--- a/00_Base/src/util/middleware/logging.middleware.ts
+++ b/00_Base/src/util/middleware/logging.middleware.ts
@@ -10,10 +10,10 @@ export class LoggingMiddleware implements KoaMiddlewareInterface {
     context: Context,
     next: (err?: any) => Promise<any>,
   ): Promise<any> {
-    console.log('do something before execution...');
+    console.log(`Received request: ${context.request}`);
     return next()
       .then(() => {
-        console.log('do something after execution');
+        console.debug('do something after execution');
       })
       .catch((error) => {
         console.log('Error intercepted by Koa:', error.message);

--- a/00_Base/src/util/middleware/ocpi.exception.handler.ts
+++ b/00_Base/src/util/middleware/ocpi.exception.handler.ts
@@ -22,7 +22,7 @@ import { UnsuccessfulRequestException } from '../../exception/UnsuccessfulReques
  */
 @Middleware({ type: 'before', priority: 10 })
 @Service()
-export class GlobalExceptionHandler implements KoaMiddlewareInterface {
+export class OcpiExceptionHandler implements KoaMiddlewareInterface {
   public async use(
     context: Context,
     next: (err?: any) => Promise<any>,
@@ -30,8 +30,7 @@ export class GlobalExceptionHandler implements KoaMiddlewareInterface {
     try {
       await next();
     } catch (err) {
-      // todo implement other errors
-      console.error('GlobalExceptionHandler error', err);
+      console.error('OcpiExceptionHandler error', err);
       if (err?.constructor?.name) {
         switch (err.constructor.name) {
           case UnauthorizedError.name:
@@ -80,7 +79,7 @@ export class GlobalExceptionHandler implements KoaMiddlewareInterface {
             );
             break;
           case UnknownTokenException.name:
-            context.status = HttpStatus.OK;
+            context.status = HttpStatus.NOT_FOUND;
             context.body = JSON.stringify(
               buildOcpiErrorResponse(
                 OcpiResponseStatusCode.ClientUnknownToken,
@@ -92,7 +91,7 @@ export class GlobalExceptionHandler implements KoaMiddlewareInterface {
             context.status = HttpStatus.NOT_FOUND;
             break;
           case InvalidParamException.name:
-            context.status = HttpStatus.OK;
+            context.status = HttpStatus.BAD_REQUEST;
             context.body = JSON.stringify(
               buildOcpiErrorResponse(
                 OcpiResponseStatusCode.ClientInvalidOrMissingParameters,
@@ -101,7 +100,7 @@ export class GlobalExceptionHandler implements KoaMiddlewareInterface {
             );
             break;
           case UnsuccessfulRequestException.name:
-            context.status = HttpStatus.OK;
+            context.status = HttpStatus.BAD_REQUEST;
             context.body = JSON.stringify(
               buildOcpiErrorResponse(
                 OcpiResponseStatusCode.ServerGenericError,

--- a/mock-client/emsp.server.ts
+++ b/mock-client/emsp.server.ts
@@ -3,7 +3,7 @@ import Koa from 'koa';
 import { VersionsController } from './versions';
 import {
   CacheWrapper,
-  GlobalExceptionHandler,
+  OcpiExceptionHandler,
   KoaServer,
   LoggingMiddleware,
   OcpiSequelizeInstance,
@@ -31,7 +31,7 @@ export class EmspServer extends KoaServer {
       this.initApp({
         controllers: [VersionsController, SessionsController, TokensController],
         routePrefix: '/ocpi',
-        middlewares: [GlobalExceptionHandler, LoggingMiddleware],
+        middlewares: [OcpiExceptionHandler, LoggingMiddleware],
         defaultErrorHandler: false,
       });
       this.initKoaSwagger(


### PR DESCRIPTION
This PR creates a separate exception handler called `HttpExceptionHandler` that returns a generic response in the event of an error, rather than the bespoke OCPI response bodies required of the main OCPI endpoints. This error handler is incorporated into the new decorator `AsAdminEndpoint` that will be used to support any admin endpoint's error handling.

The original `GlobalExceptionHandler` was renamed to `OcpiExceptionHandler` as a result of the change above.