### PR TITLE
Feature: Created Transactions with Country Code and Party Id Postgres View.

### DIFF
--- a/00_Base/src/index.ts
+++ b/00_Base/src/index.ts
@@ -29,6 +29,7 @@ import {
 import { SessionBroadcaster } from './broadcaster/session.broadcaster';
 import { CdrBroadcaster } from './broadcaster/cdr.broadcaster';
 
+export { createViewTransactionsWithPartyIdAndCountryCodeSql, dropViewTransactionsWithPartyIdAndCountryCodeSql } from './sql/ViewTransactionsWithPartyIdAndCountryCode';
 export { NotFoundException } from './exception/NotFoundException';
 export { FunctionalEndpointParams } from './util/decorators/FunctionEndpointParams';
 export { PaginatedOcpiParams } from './trigger/param/paginated.ocpi.params';

--- a/00_Base/src/model/view/ViewTransactionsWithPartyIdAndCountryCode.ts
+++ b/00_Base/src/model/view/ViewTransactionsWithPartyIdAndCountryCode.ts
@@ -1,0 +1,54 @@
+import { Column, DataType, Model, Table } from 'sequelize-typescript';
+import { IsNotEmpty, IsString, Length } from 'class-validator';
+import { SyncOptions } from 'sequelize';
+import { Views } from '../../sql/views';
+import { dropViewTransactionsWithPartyIdAndCountryCodeSql } from '../../sql/ViewTransactionsWithPartyIdAndCountryCode';
+
+export enum ViewTransactionsWithPartyIdAndCountryCodeProps {
+  partyId = 'party_id',
+  countryCode = 'country_code',
+  stationId = 'stationId',
+  station = 'station',
+  evse = 'evse',
+  evseDatabaseId = 'evseDatabaseId',
+  transactionId = 'transactionId',
+  isActive = 'isActive',
+  transactionEvents = 'transactionEvents',
+  meterValues = 'meterValues',
+  chargingState = 'chargingState',
+  timeSpentCharging = 'timeSpentCharging',
+  totalKwh = 'totalKwh',
+  stoppedReason = 'stoppedReason',
+  remoteStartId = 'remoteStartId',
+  customData = 'customData',
+}
+
+@Table({
+  modelName: Views.ViewTransactionsWithPartyIdAndCountryCodes,
+  createdAt: false,
+  updatedAt: false
+})
+export class ViewTransactionsWithPartyIdAndCountryCode extends Model {
+
+  @Column({ primaryKey: true, autoIncrement: true })
+  id!: number
+
+  @Column(DataType.STRING(3))
+  @IsString()
+  @IsNotEmpty()
+  @Length(3, 3)
+  [ViewTransactionsWithPartyIdAndCountryCodeProps.partyId]!: string;
+
+  @Column(DataType.STRING(2))
+  @IsString()
+  @IsNotEmpty()
+  @Length(2, 2)
+  [ViewTransactionsWithPartyIdAndCountryCodeProps.countryCode]!: string;
+
+  // disables sync so that a new table is not created since we want to use the view.
+  static async sync(options: SyncOptions): Promise<any> {
+    if (options.force) {
+      await this.sequelize?.query(dropViewTransactionsWithPartyIdAndCountryCodeSql)
+    }
+  }
+}

--- a/00_Base/src/model/view/ViewTransactionsWithPartyIdAndCountryCode.ts
+++ b/00_Base/src/model/view/ViewTransactionsWithPartyIdAndCountryCode.ts
@@ -45,6 +45,11 @@ export class ViewTransactionsWithPartyIdAndCountryCode extends Model {
   @Length(2, 2)
   [ViewTransactionsWithPartyIdAndCountryCodeProps.countryCode]!: string;
 
+  @IsString()
+  @IsNotEmpty()
+  @Column(DataType.STRING)
+  [ViewTransactionsWithPartyIdAndCountryCodeProps.transactionId]!: string;
+
   // disables sync so that a new table is not created since we want to use the view.
   static async sync(options: SyncOptions): Promise<any> {
     if (options.force) {

--- a/00_Base/src/repository/ViewTransactionsWithPartyIdAndCountryCodeRepository.ts
+++ b/00_Base/src/repository/ViewTransactionsWithPartyIdAndCountryCodeRepository.ts
@@ -1,0 +1,24 @@
+import { SequelizeRepository } from '@citrineos/data';
+import { SystemConfig } from '@citrineos/base';
+import { Service } from 'typedi';
+import { OcpiServerConfig } from '../config/ocpi.server.config';
+import { ILogObj, Logger } from 'tslog';
+import { OcpiSequelizeInstance } from '../util/sequelize';
+import { OcpiNamespace } from '../util/ocpi.namespace';
+import { ViewTransactionsWithPartyIdAndCountryCode } from '../model/view/ViewTransactionsWithPartyIdAndCountryCode';
+
+@Service()
+export class ViewTransactionsWithPartyIdAndCountryCodeRepository extends SequelizeRepository<ViewTransactionsWithPartyIdAndCountryCode> {
+  constructor(
+    ocpiSystemConfig: OcpiServerConfig,
+    logger: Logger<ILogObj>,
+    ocpiSequelizeInstance: OcpiSequelizeInstance,
+  ) {
+    super(
+      ocpiSystemConfig as SystemConfig,
+      OcpiNamespace.TransactionsWithPartyIdAndCountryCode,
+      logger,
+      ocpiSequelizeInstance.sequelize,
+    );
+  }
+}

--- a/00_Base/src/services/sessions.service.ts
+++ b/00_Base/src/services/sessions.service.ts
@@ -1,20 +1,23 @@
 import { Service } from 'typedi';
 import { PaginatedSessionResponse } from '../model/Session';
 import { SequelizeTransactionEventRepository } from '@citrineos/data';
-import {
-  buildOcpiPaginatedResponse,
-  DEFAULT_LIMIT,
-  DEFAULT_OFFSET,
-} from '../model/PaginatedResponse';
+import { buildOcpiPaginatedResponse, DEFAULT_LIMIT, DEFAULT_OFFSET } from '../model/PaginatedResponse';
 import { SessionMapper } from '../mapper/session.mapper';
 import { OcpiResponseStatusCode } from '../model/ocpi.response';
+import {
+  ViewTransactionsWithPartyIdAndCountryCodeRepository,
+} from '../repository/ViewTransactionsWithPartyIdAndCountryCodeRepository';
 
 @Service()
 export class SessionsService {
   constructor(
     private readonly transactionRepository: SequelizeTransactionEventRepository,
     private readonly sessionMapper: SessionMapper,
-  ) {}
+    private readonly viewTransactionsWithPartyIdAndCountryCodeRepository: ViewTransactionsWithPartyIdAndCountryCodeRepository,
+  ) {
+    // todo temp
+    // this.test();
+  }
 
   public async getSessions(
     fromCountryCode: string,
@@ -54,4 +57,16 @@ export class SessionsService {
 
     return response as PaginatedSessionResponse;
   }
+
+  /* todo temp for testing
+  private test() {
+    this.viewTransactionsWithPartyIdAndCountryCodeRepository.readAllByQuery({
+      where: {
+        [ViewTransactionsWithPartyIdAndCountryCodeProps.countryCode]: 'US',
+        [ViewTransactionsWithPartyIdAndCountryCodeProps.partyId]: 'CPO',
+      }
+    }).then((r) => {
+      console.log('herhe', r);
+    });
+  }*/
 }

--- a/00_Base/src/sql/ViewTransactionsWithPartyIdAndCountryCode.ts
+++ b/00_Base/src/sql/ViewTransactionsWithPartyIdAndCountryCode.ts
@@ -1,0 +1,23 @@
+import { Views } from './views';
+
+export const createViewTransactionsWithPartyIdAndCountryCodeSql = `
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_views WHERE viewname = '${Views.ViewTransactionsWithPartyIdAndCountryCodes}') THEN
+        EXECUTE '
+        CREATE VIEW "${Views.ViewTransactionsWithPartyIdAndCountryCodes}" AS
+        SELECT
+            "Transactions".*,
+            "OcpiLocations".country_code AS "country_code",
+            "OcpiLocations".party_id AS "party_id"
+        FROM "Transactions"
+        JOIN "ChargingStations" ON "Transactions"."stationId" = "ChargingStations"."id"
+        JOIN "OcpiLocations" ON "ChargingStations"."locationId" = "OcpiLocations"."id";
+        ';
+    END IF;
+END $$;
+`;
+
+export const dropViewTransactionsWithPartyIdAndCountryCodeSql = `
+  DROP VIEW IF EXISTS ${Views.ViewTransactionsWithPartyIdAndCountryCodes};
+`;

--- a/00_Base/src/sql/views.ts
+++ b/00_Base/src/sql/views.ts
@@ -1,0 +1,3 @@
+export enum Views {
+  ViewTransactionsWithPartyIdAndCountryCodes = 'ViewTransactionsWithPartyIdAndCountryCodes',
+}

--- a/00_Base/src/util/ocpi.namespace.ts
+++ b/00_Base/src/util/ocpi.namespace.ts
@@ -1,3 +1,5 @@
+import { Views } from '../sql/views';
+
 export enum OcpiNamespace {
   Credentials = 'Credentials',
   Version = 'Version',
@@ -16,4 +18,5 @@ export enum OcpiNamespace {
   OcpiEvse = 'OcpiEvse',
   OcpiConnector = 'OcpiConnector',
   ResponseUrlCorrelationId = 'ResponseUrlCorrelationId',
+  TransactionsWithPartyIdAndCountryCode = Views.ViewTransactionsWithPartyIdAndCountryCodes,
 }

--- a/migrations/20240722112656-view-transactions-with-party-id-and-country-code.ts
+++ b/migrations/20240722112656-view-transactions-with-party-id-and-country-code.ts
@@ -1,0 +1,19 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+import { QueryInterface } from 'sequelize';
+import {
+  createViewTransactionsWithPartyIdAndCountryCodeSql,
+  dropViewTransactionsWithPartyIdAndCountryCodeSql,
+} from '@citrineos/ocpi-base';
+
+
+export = {
+  up: async (queryInterface: QueryInterface) => {
+    await queryInterface.sequelize.query(createViewTransactionsWithPartyIdAndCountryCodeSql);
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    await queryInterface.sequelize.query(dropViewTransactionsWithPartyIdAndCountryCodeSql);
+  },
+};

--- a/migrations/package.json
+++ b/migrations/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@citrineos/ocpi-migrations",
+  "version": "0.2.0",
+  "description": "Package to handle migrations",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "prepublish": "npx eslint",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "compile": "npm run clean && tsc -p tsconfig.json",
+    "clean": "rm -rf dist/* tsconfig.tsbuildinfo",
+    "fresh": "rm -rf node_modules package-lock.json && npm run clean"
+  },
+  "keywords": [
+    "ocpp",
+    "ocpp_v201"
+  ],
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@types/deasync-promise": "^1.0.0",
+    "eslint": "^8.48.0",
+    "typescript": "^5.0.4"
+  },
+  "dependencies": {
+    "@citrineos/ocpi-base": "0.2.0"
+  },
+  "workspaces": [
+    "../00_Base"
+  ]
+}

--- a/migrations/tsconfig.json
+++ b/migrations/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["src/**/*.ts", "src/**/*.json"],
+  "exclude": ["**/dist/**", "**/node_modules/**"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "references": [
+    {
+      "path": "../00_Base"
+    }
+  ]
+}


### PR DESCRIPTION
feat: created ViewTransactionsWithPartyIdAndCountryCode model and view to allow us to query for transactions for particular partyId and country code. Created a migration to create the view. Adjusted sequelize initialization to drop and recreate views before and after running the sequelize.sync to ensure that migrations do not have a conflict when trying to alter a column for a table that is part of a view. Created a repository and a simple test (commented out) to show that using this view we are able to query for transactions based on country code and party id.

<img width="2044" alt="Screenshot 2024-07-22 at 3 18 17 PM" src="https://github.com/user-attachments/assets/1a3826bc-6d25-4d6d-938c-2ea7dbd04f30">
<img width="1605" alt="Screenshot 2024-07-22 at 2 58 51 PM" src="https://github.com/user-attachments/assets/4dbd3ee1-2513-4117-aeb3-de230929e4a4">

Pairs with: https://github.com/citrineos/citrineos-core/pull/176
