### PR TITLE
chore: reverting version back to 1.3.1

### DIFF
--- a/00_Base/package.json
+++ b/00_Base/package.json
@@ -32,8 +32,8 @@
     "@types/lodash.startcase": "^4.4.9"
   },
   "dependencies": {
-    "@citrineos/base": "1.3.2",
-    "@citrineos/data": "1.3.2",
+    "@citrineos/base": "1.3.1",
+    "@citrineos/data": "1.3.1",
     "@typescript-eslint/eslint-plugin": "^6.5.0",
     "ajv": "^8.12.0",
     "class-transformer": "^0.5.1",

--- a/03_Modules/Cdrs/package.json
+++ b/03_Modules/Cdrs/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@citrineos/ocpi-base": "0.1.1",
-    "@citrineos/base": "1.3.2",
-    "@citrineos/util": "1.3.2",
+    "@citrineos/base": "1.3.1",
+    "@citrineos/util": "1.3.1",
     "deasync-promise": "^1.0.1",
     "tslog": "^4.9.2"
   }

--- a/03_Modules/ChargingProfiles/package.json
+++ b/03_Modules/ChargingProfiles/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@citrineos/ocpi-base": "0.1.1",
-    "@citrineos/base": "1.3.2",
-    "@citrineos/util": "1.3.2",
+    "@citrineos/base": "1.3.1",
+    "@citrineos/util": "1.3.1",
     "deasync-promise": "^1.0.1",
     "tslog": "^4.9.2"
   }

--- a/03_Modules/Commands/package.json
+++ b/03_Modules/Commands/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@citrineos/ocpi-base": "0.1.1",
-    "@citrineos/util": "1.3.2",
+    "@citrineos/util": "1.3.1",
     "deasync-promise": "^1.0.1",
     "tslog": "^4.9.2"
   }

--- a/03_Modules/Locations/package.json
+++ b/03_Modules/Locations/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@citrineos/ocpi-base": "0.1.1",
-    "@citrineos/base": "1.3.2",
-    "@citrineos/util": "1.3.2",
+    "@citrineos/base": "1.3.1",
+    "@citrineos/util": "1.3.1",
     "deasync-promise": "^1.0.1",
     "tslog": "^4.9.2",
     "@types/geojson": "7946.0.14"

--- a/03_Modules/Sessions/package.json
+++ b/03_Modules/Sessions/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@citrineos/ocpi-base": "0.1.1",
-    "@citrineos/base": "1.3.2",
-    "@citrineos/util": "1.3.2",
+    "@citrineos/base": "1.3.1",
+    "@citrineos/util": "1.3.1",
     "deasync-promise": "^1.0.1",
     "tslog": "^4.9.2"
   }

--- a/03_Modules/Tariffs/package.json
+++ b/03_Modules/Tariffs/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@citrineos/ocpi-base": "0.1.1",
-    "@citrineos/base": "1.3.2",
-    "@citrineos/util": "1.3.2",
+    "@citrineos/base": "1.3.1",
+    "@citrineos/util": "1.3.1",
     "deasync-promise": "^1.0.1",
     "tslog": "^4.9.2"
   }

--- a/03_Modules/Tokens/package.json
+++ b/03_Modules/Tokens/package.json
@@ -27,9 +27,9 @@
   },
   "dependencies": {
     "@citrineos/ocpi-base": "0.1.1",
-    "@citrineos/base": "1.3.2",
-    "@citrineos/data": "1.3.2",
-    "@citrineos/util": "1.3.2",
+    "@citrineos/base": "1.3.1",
+    "@citrineos/data": "1.3.1",
+    "@citrineos/util": "1.3.1",
     "deasync-promise": "^1.0.1",
     "tslog": "^4.9.2"
   }

--- a/03_Modules/Versions/package.json
+++ b/03_Modules/Versions/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@citrineos/ocpi-base": "0.1.1",
-    "@citrineos/util": "1.3.2",
+    "@citrineos/util": "1.3.1",
     "deasync-promise": "^1.0.1",
     "tslog": "^4.9.2"
   }

--- a/seeders/package.json
+++ b/seeders/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@citrineos/ocpi-base": "0.1.1",
-    "@citrineos/base": "1.3.2",
-    "@citrineos/data": "1.3.2"
+    "@citrineos/base": "1.3.1",
+    "@citrineos/data": "1.3.1"
   },
   "workspaces": [
     "../00_Base",


### PR DESCRIPTION
chore: reverting version back to 1.3.1 because otherwise breaks ci in OCPI