### PR TITLE
Fix: Workflows to pull rc candidate branches for OCPI and CORE

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Clone citrineos-core repository
-        run: git clone https://github.com/citrineos/citrineos-core.git ../citrineos-core
+        run: git clone -b rc-1.3.2 https://github.com/citrineos/citrineos-core.git ../citrineos-core
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3


### PR DESCRIPTION
fix: adjusting workflows to clone rc branch for now otherwise CI breaks, then this can be toggled back to main as part of release
