### PR TITLE
Bugfix: "removed" type annotation from IsString -> IsBoolean

### DIFF
--- a/00_Base/src/model/DTO/admin/AdminLocationDTO.ts
+++ b/00_Base/src/model/DTO/admin/AdminLocationDTO.ts
@@ -34,7 +34,7 @@ export class AdminEvseDTO {
   @Optional()
   physical_reference?: string;
 
-  @IsString()
+  @IsBoolean()
   @Optional()
   removed?: boolean;
 


### PR DESCRIPTION
Quick PR to fix the wrong type annotation above the `removed` property, which is supposed to be a boolean.