### PR TITLE
PUT instead of PATCH last session to MSP

### DIFF
--- a/00_Base/src/broadcaster/session.broadcaster.ts
+++ b/00_Base/src/broadcaster/session.broadcaster.ts
@@ -6,6 +6,7 @@ import {
   SequelizeTransactionEventRepository,
   Transaction,
   TransactionEvent,
+  Evse,
 } from '@citrineos/data';
 import { SessionMapper } from '../mapper/session.mapper';
 import { CredentialsService } from '../services/credentials.service';
@@ -14,11 +15,18 @@ import { BaseBroadcaster } from './BaseBroadcaster';
 import { ModuleId } from '../model/ModuleId';
 import { PatchSessionParams } from '../trigger/param/sessions/patch.session.params';
 import { PutSessionParams } from '../trigger/param/sessions/put.session.params';
-import { TriggerReasonEnumType } from '@citrineos/base';
+import {
+  TriggerReasonEnumType,
+  TransactionEventEnumType,
+} from '@citrineos/base';
 import { InternalServerError } from 'routing-controllers';
+import { SessionStatus } from '../model/SessionStatus';
 
 @Service()
 export class SessionBroadcaster extends BaseBroadcaster {
+  private TRANSACTION_EVENTS_DATA_VALUES = 'transactionEvents';
+  private METER_VALUES_DATA_VALUES = 'meterValues';
+
   constructor(
     readonly logger: Logger<ILogObj>,
     readonly transactionEventRepository: SequelizeTransactionEventRepository,
@@ -93,6 +101,7 @@ export class SessionBroadcaster extends BaseBroadcaster {
                       as: Transaction.TRANSACTION_EVENTS_ALIAS,
                       include: [IdToken],
                     },
+                    Evse,
                   ],
                 },
               );
@@ -126,7 +135,10 @@ export class SessionBroadcaster extends BaseBroadcaster {
               );
 
             for (const session of sessions) {
-              await this.sendSessionToClients(session, true);
+              await this.sendSessionToClients(
+                session,
+                session.status !== SessionStatus.COMPLETED,
+              );
             }
           }
         }
@@ -148,13 +160,32 @@ export class SessionBroadcaster extends BaseBroadcaster {
         if (transactionId) {
           const transaction = transactionsMap[transactionId];
           if (transaction) {
-            transaction.setDataValue('transactionEvents', [transactionEvent]); // todo use Props
+            let finalTransactionEvents = [];
+            let finalMeterValues = [];
+            if (transactionEvent.eventType === TransactionEventEnumType.Ended) {
+              finalTransactionEvents = [
+                ...(transaction.transactionEvents ?? []),
+                transactionEvent,
+              ];
+              finalMeterValues = [
+                ...(transaction.meterValues ?? []),
+                ...transactionEvent.meterValue,
+              ];
+            } else {
+              finalTransactionEvents = [transactionEvent];
+              finalMeterValues = transactionEvent.meterValue;
+            }
+
             transaction.setDataValue(
-              'meterValues',
-              transactionEvent.meterValue,
+              this.TRANSACTION_EVENTS_DATA_VALUES,
+              finalTransactionEvents,
             ); // todo use Props
-            transaction.transactionEvents = [transactionEvent];
-            transaction.meterValues = transactionEvent.meterValue;
+            transaction.setDataValue(
+              this.METER_VALUES_DATA_VALUES,
+              finalMeterValues,
+            ); // todo use Props
+            transaction.transactionEvents = finalTransactionEvents;
+            transaction.meterValues = finalMeterValues;
           }
         }
       } else {

--- a/00_Base/src/services/TransactionQueryBuilder.ts
+++ b/00_Base/src/services/TransactionQueryBuilder.ts
@@ -64,7 +64,7 @@ export class TransactionQueryBuilder {
     dateTo?: Date,
   ): void {
     if (dateFrom || dateTo) {
-      queryOptions.where =  { ...(queryOptions.where ?? {}), updatedAt: {} };
+      queryOptions.where = { ...(queryOptions.where ?? {}), updatedAt: {} };
       if (dateFrom) {
         queryOptions.where.updatedAt[Op.gte] = dateFrom;
       }


### PR DESCRIPTION
This PR adds logic to PUT instead of PATCH the final session to MSP, which involves ensuring the full scope of data is available to map a session if the session has ended.