### PR TITLE
Make release candidate branches base branches for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,5 @@
   "dependencyDashboard": true,
   "branchPrefix": "renovate/",
   "commitMessagePrefix": "📦 chore(deps): ",
-  "baseBranch": "rc-1.0.0"
+  "baseBranches": ["main", "^rc-\\d+\\.\\d+\\.\\d+$"]
 }


### PR DESCRIPTION
Allow release candidate (`rc-x.x.x`) branches as base branch for renovate to update dependancies off of