### PR TITLE
fix: PUT Tariffs endpoint incorrect response body

### DIFF
--- a/00_Base/src/index.ts
+++ b/00_Base/src/index.ts
@@ -229,6 +229,7 @@ export { LocationsBroadcaster } from './broadcaster/locations.broadcaster';
 export {
   PaginatedTariffResponse,
   TariffDTO,
+  TariffResponse,
 } from './model/DTO/tariffs/TariffDTO';
 export { OcpiLocation, OcpiLocationProps } from './model/OcpiLocation';
 export { OcpiEvse } from './model/OcpiEvse';

--- a/00_Base/src/model/DTO/tariffs/TariffDTO.ts
+++ b/00_Base/src/model/DTO/tariffs/TariffDTO.ts
@@ -3,6 +3,7 @@ import {
   IsArray,
   IsDateString,
   IsNotEmpty,
+  IsObject,
   IsString,
   IsUrl,
   MaxLength,
@@ -17,6 +18,7 @@ import { TariffElement } from '../../TariffElement';
 import { EnergyMix } from '../../EnergyMix';
 import { DisplayText } from '../../DisplayText';
 import { TariffType } from '../../TariffType';
+import { OcpiResponse, OcpiResponseStatusCode } from '../../ocpi.response';
 
 export class TariffDTO {
   @MaxLength(36)
@@ -104,4 +106,26 @@ export class PaginatedTariffResponse extends PaginatedResponse<TariffDTO> {
   @Optional(false)
   @Type(() => TariffDTO)
   data!: TariffDTO[];
+}
+
+export class TariffResponse extends OcpiResponse<TariffDTO> {
+  @IsObject()
+  @IsNotEmpty()
+  @Type(() => TariffDTO)
+  @ValidateNested()
+  data!: TariffDTO;
+
+  static build(
+    tariff: TariffDTO,
+    status_code = OcpiResponseStatusCode.GenericSuccessCode,
+    status_message?: string,
+  ) {
+    const response = new TariffResponse();
+    response.data = new TariffDTO();
+    response.status_code = status_code;
+    response.status_message = status_message;
+    response.data = tariff;
+    response.timestamp = new Date();
+    return response;
+  }
 }

--- a/00_Base/src/model/Tariff.ts
+++ b/00_Base/src/model/Tariff.ts
@@ -3,7 +3,6 @@ import {
   IsArray,
   IsDateString,
   IsNotEmpty,
-  IsObject,
   IsString,
   IsUrl,
   MaxLength,
@@ -17,7 +16,6 @@ import { DisplayText } from './DisplayText';
 import { Type } from 'class-transformer';
 import { Optional } from '../util/decorators/optional';
 import { PaginatedResponse } from './PaginatedResponse';
-import { OcpiResponse } from './ocpi.response';
 
 export class Tariff {
   @MaxLength(36)
@@ -96,14 +94,6 @@ export class Tariff {
   @IsNotEmpty()
   @Type(() => Date)
   last_updated!: Date;
-}
-
-export class TariffResponse extends OcpiResponse<Tariff> {
-  @IsObject()
-  @IsNotEmpty()
-  @Type(() => Tariff)
-  @ValidateNested()
-  data!: Tariff;
 }
 
 export class PaginatedTariffResponse extends PaginatedResponse<Tariff> {

--- a/00_Base/src/trigger/TariffsClientApi.ts
+++ b/00_Base/src/trigger/TariffsClientApi.ts
@@ -1,5 +1,5 @@
 import { BaseClientApi } from './BaseClientApi';
-import { TariffResponse } from '../model/Tariff';
+import { TariffResponse } from '../model/DTO/tariffs/TariffDTO';
 import { GetTariffParams } from './param/tariffs/get.tariff.params';
 import { PutTariffParams } from './param/tariffs/put.tariff.params';
 import { DeleteTariffParams } from './param/tariffs/delete.tariff.params';

--- a/03_Modules/Tariffs/src/module/api.ts
+++ b/03_Modules/Tariffs/src/module/api.ts
@@ -33,8 +33,8 @@ import {
   PaginatedTariffResponse,
   PutTariffRequest,
   ResponseSchema,
-  TariffDTO,
   TariffKey,
+  TariffResponse,
   TariffsBroadcaster,
   TariffsService,
   versionIdParam,
@@ -116,8 +116,11 @@ export class TariffsModuleApi
    */
 
   @Put()
-  async updateTariff(@Body() tariffDto: PutTariffRequest): Promise<TariffDTO> {
-    return await this.tariffService.createOrUpdateTariff(tariffDto);
+  async updateTariff(
+    @Body() tariffDto: PutTariffRequest,
+  ): Promise<TariffResponse> {
+    const tariff = await this.tariffService.createOrUpdateTariff(tariffDto);
+    return TariffResponse.build(tariff);
   }
 
   @Delete('/:tariffId')


### PR DESCRIPTION
fix: PUT Tariffs endpoint to ensure that response body is an OcpiResponse whereas it was only sending the tariff directly
<img width="1211" alt="Screenshot 2024-08-20 at 1 34 31 PM" src="https://github.com/user-attachments/assets/ab6ec088-bc7f-465d-9179-80cafbf305b8">
