### PR TITLE
Fix: npm run seed-db & npm run sync-db

### DIFF
--- a/00_Base/src/config/sequalize.bridge.config.js
+++ b/00_Base/src/config/sequalize.bridge.config.js
@@ -1,4 +1,5 @@
 /* eslint-disable */
+require('reflect-metadata');
 require('ts-node/register');
 require('tsconfig-paths/register');
 const { ServerConfig } = require('./ServerConfig.ts');

--- a/00_Base/src/config/sequalize.bridge.config.js
+++ b/00_Base/src/config/sequalize.bridge.config.js
@@ -1,11 +1,11 @@
 /* eslint-disable */
 require('ts-node/register');
 require('tsconfig-paths/register');
-const { OcpiServerConfig } = require('./ocpi.server.config.ts');
+const { ServerConfig } = require('./ServerConfig.ts');
 
 //TODO eliminate this file and use the typescript file directly
 
-const ocpiConfig = new OcpiServerConfig();
+const ocpiConfig = new ServerConfig();
 const { host, port, database, dialect, username, password, storage } =
   ocpiConfig.data.sequelize;
 

--- a/db.sync.ts
+++ b/db.sync.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { OcpiSequelizeInstance, ServerConfig } from '@citrineos/ocpi-base';
 
 const ocpiSequelizeInstance = new OcpiSequelizeInstance(new ServerConfig());

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "eslint-config-prettier": "9.1.0",
     "prettier": "3.2.5",
     "typescript": "5.5.4",
-    "typescript-eslint": "7.6.0"
+    "typescript-eslint": "7.6.0",
+    "sequelize-cli": "6.6.2"
   },
   "scripts": {
     "test": "jest --config jest.config.js",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "prettier": "3.2.5",
     "typescript": "5.5.4",
     "typescript-eslint": "7.6.0",
-    "sequelize-cli": "6.6.2"
+    "sequelize-cli": "6.6.2",
+    "reflect-metadata": "0.2.2"
   },
   "scripts": {
     "test": "jest --config jest.config.js",


### PR DESCRIPTION
Intended to resolve - https://github.com/citrineos/citrineos/issues/52

- fix: updating sequelize.bridge.config.js to use updated ServerConfig file
- fix: adjusting sequelize.bridge.config.js and db.sync.ts to import reflect-metadata to resolve Reflect not defined error
- fix: installing sequelize-cli because it was not in the dependency tree