### PR TITLE
Update device model queries to include relevant Variable Attribute type

### DIFF
--- a/00_Base/src/model/variableattributes/ChargingStationVariableAttributes.ts
+++ b/00_Base/src/model/variableattributes/ChargingStationVariableAttributes.ts
@@ -48,7 +48,8 @@ export const CONSTRUCT_CHARGING_STATION_VARIABLE_ATTRIBUTES_QUERY = (
           left join "Variables" v on va."variableId" = v."id" 
           left join "Components" c on va."componentId" = c."id"
           left join "Evses" e on c."evseDatabaseId" = e."databaseId"
-        where va."stationId" = '${stationId}' and e."id" is not null
+        where va."stationId" = '${stationId}' and 
+          e."id" is not null
       ), ''
     ) as evse_ids_string,
     coalesce(
@@ -57,7 +58,10 @@ export const CONSTRUCT_CHARGING_STATION_VARIABLE_ATTRIBUTES_QUERY = (
         from "VariableAttributes" va 
           left join "Variables" v on va."variableId" = v."id" 
           left join "Components" c on va."componentId" = c."id"
-        where va."stationId" = '${stationId}' and c."name" = 'AuthCtrlr' and v."name" = 'AuthorizeRemoteStart'
+        where va."stationId" = '${stationId}' and 
+          va."type" = 'Actual' and
+          c."name" = 'AuthCtrlr' and 
+          v."name" = 'AuthorizeRemoteStart'
       ), 'FALSE'
     ) as authorize_remote_start,
     coalesce(
@@ -66,7 +70,10 @@ export const CONSTRUCT_CHARGING_STATION_VARIABLE_ATTRIBUTES_QUERY = (
         from "VariableAttributes" va 
           left join "Variables" v on va."variableId" = v."id" 
           left join "Components" c on va."componentId" = c."id"
-        where va."stationId" = '${stationId}' and c."name" = 'BayOccupancySensor' and v."name" = 'Active'
+        where va."stationId" = '${stationId}' and 
+          va."type" = 'Actual' and
+          c."name" = 'BayOccupancySensor' and 
+          v."name" = 'Active'
       ), 'FALSE'
     ) as bay_occupancy_sensor_active,
     coalesce(
@@ -75,7 +82,10 @@ export const CONSTRUCT_CHARGING_STATION_VARIABLE_ATTRIBUTES_QUERY = (
         from "VariableAttributes" va 
           left join "Variables" v on va."variableId" = v."id" 
           left join "Components" c on va."componentId" = c."id"
-        where va."stationId" = '${stationId}' and c."name" = 'TokenReader' and v."name" = 'Enabled'
+        where va."stationId" = '${stationId}' and 
+          va."type" = 'Actual' and
+          c."name" = 'TokenReader' and 
+          v."name" = 'Enabled'
       ), 'FALSE'
     ) as token_reader_enabled;
 `;

--- a/00_Base/src/model/variableattributes/ConnectorVariableAttributes.ts
+++ b/00_Base/src/model/variableattributes/ConnectorVariableAttributes.ts
@@ -38,7 +38,12 @@ export const CONSTRUCT_CONNECTOR_VARIABLE_ATTRIBUTES_QUERY = (
           left join "Variables" v on va."variableId" = v."id" 
           left join "Components" c on va."componentId" = c."id"
           left join "Evses" e on c."evseDatabaseId" = e."databaseId" 
-        where va."stationId" = '${stationId}' and e."id" = ${evseComponentId} and e."connectorId" = ${connectorId} and c."name" = 'Connector' and v."name" = 'ConnectorType'
+        where va."stationId" = '${stationId}' and 
+          va."type" = 'Actual' and
+          e."id" = ${evseComponentId} and 
+          e."connectorId" = ${connectorId} and 
+          c."name" = 'Connector' and 
+          v."name" = 'ConnectorType'
       ), 'Unknown'
     ) as connector_type,
     coalesce(
@@ -48,7 +53,12 @@ export const CONSTRUCT_CONNECTOR_VARIABLE_ATTRIBUTES_QUERY = (
           left join "Variables" v on va."variableId" = v."id" 
           left join "Components" c on va."componentId" = c."id"
           left join "Evses" e on c."evseDatabaseId" = e."databaseId" 
-        where va."stationId" = '${stationId}' and e."id" = ${evseComponentId} and e."connectorId" = ${connectorId} and c."name" = 'Connector' and v."name" = 'AvailabilityState'
+        where va."stationId" = '${stationId}' and 
+          va."type" = 'Actual' and
+          e."id" = ${evseComponentId} and 
+          e."connectorId" = ${connectorId} and 
+          c."name" = 'Connector' and 
+          v."name" = 'AvailabilityState'
       ), 'Unavailable'
     ) as connector_availability_state;
 `;

--- a/00_Base/src/model/variableattributes/EvseVariableAttributes.ts
+++ b/00_Base/src/model/variableattributes/EvseVariableAttributes.ts
@@ -52,11 +52,13 @@ export const CONSTRUCT_EVSE_VARIABLE_ATTRIBUTES_QUERY = (
   from 
     coalesce(
       (
-        select string_agg(distinct e."connectorId"::text, ',') from "VariableAttributes" va 
-        left join "Variables" v on va."variableId" = v."id" 
-        left join "Components" c on va."componentId" = c."id"
-        left join "Evses" e on c."evseDatabaseId" = e."databaseId"
-        where va."stationId" = '${stationId}' and e."connectorId" is not null
+        select string_agg(distinct e."connectorId"::text, ',') 
+        from "VariableAttributes" va 
+          left join "Variables" v on va."variableId" = v."id" 
+          left join "Components" c on va."componentId" = c."id"
+          left join "Evses" e on c."evseDatabaseId" = e."databaseId"
+        where va."stationId" = '${stationId}' and 
+          e."connectorId" is not null
       ), ''
     ) as connector_ids_string,
     coalesce(
@@ -66,7 +68,11 @@ export const CONSTRUCT_EVSE_VARIABLE_ATTRIBUTES_QUERY = (
           left join "Variables" v on va."variableId" = v."id" 
           left join "Components" c on va."componentId" = c."id"
           left join "Evses" e on c."evseDatabaseId" = e."databaseId" 
-        where va."stationId" = '${stationId}' and e."id" = ${evseComponentId} and c."name" = 'EVSE' and v."name" = 'AvailabilityState'
+        where va."stationId" = '${stationId}' and 
+          va."type" = 'Actual' and
+          e."id" = ${evseComponentId} and 
+          c."name" = 'EVSE' and 
+          v."name" = 'AvailabilityState'
       ), 'Unavailable'
     ) as evse_availability_state,
     coalesce(
@@ -76,7 +82,11 @@ export const CONSTRUCT_EVSE_VARIABLE_ATTRIBUTES_QUERY = (
           left join "Variables" v on va."variableId" = v."id" 
           left join "Components" c on va."componentId" = c."id"
           left join "Evses" e on c."evseDatabaseId" = e."databaseId" 
-        where va."stationId" = '${stationId}' and e."id" = ${evseComponentId} and c."name" = 'EVSE' and v."name" = 'EvseId'
+        where va."stationId" = '${stationId}' and 
+          va."type" = 'Actual' and
+          e."id" = ${evseComponentId} and 
+          c."name" = 'EVSE' and 
+          v."name" = 'EvseId'
       ), 'Unknown'
     ) as evse_id,
     coalesce(
@@ -86,7 +96,11 @@ export const CONSTRUCT_EVSE_VARIABLE_ATTRIBUTES_QUERY = (
           left join "Variables" v on va."variableId" = v."id" 
           left join "Components" c on va."componentId" = c."id"
           left join "Evses" e on c."evseDatabaseId" = e."databaseId" 
-        where va."stationId" = '${stationId}' and e."id" = ${evseComponentId} and c."name" = 'EVSE' and v."name" = 'DCVoltage'
+        where va."stationId" = '${stationId}' and 
+          va."type" = 'MaxSet' and
+          e."id" = ${evseComponentId} and 
+          c."name" = 'EVSE' and 
+          v."name" = 'DCVoltage'
       ), '0'
     ) as evse_dc_voltage,
     coalesce(
@@ -96,7 +110,11 @@ export const CONSTRUCT_EVSE_VARIABLE_ATTRIBUTES_QUERY = (
           left join "Variables" v on va."variableId" = v."id" 
           left join "Components" c on va."componentId" = c."id"
           left join "Evses" e on c."evseDatabaseId" = e."databaseId" 
-        where va."stationId" = '${stationId}' and e."id" = ${evseComponentId} and c."name" = 'EVSE' and v."name" = 'DCCurrent'
+        where va."stationId" = '${stationId}' and 
+          va."type" = 'MaxSet' and
+          e."id" = ${evseComponentId} and 
+          c."name" = 'EVSE' and 
+          v."name" = 'DCCurrent'
       ), '0'
     ) as evse_dc_current,
     coalesce(
@@ -106,7 +124,11 @@ export const CONSTRUCT_EVSE_VARIABLE_ATTRIBUTES_QUERY = (
           left join "Variables" v on va."variableId" = v."id" 
           left join "Components" c on va."componentId" = c."id"
           left join "Evses" e on c."evseDatabaseId" = e."databaseId" 
-        where va."stationId" = '${stationId}' and e."id" = 1 and c."name" = 'EVSE' and v."name" = 'Power'
+        where va."stationId" = '${stationId}' and 
+          va."type" = 'MaxSet' and
+          e."id" = 1 and 
+          c."name" = 'EVSE' and 
+          v."name" = 'Power'
       ), '0'
     ) as evse_power;
 `;


### PR DESCRIPTION
Resolves issue https://github.com/citrineos/citrineos/issues/98 - this PR adds an additional condition to the SQL queries that retrieve relevant device model information to also include the relevant Variable Attribute type.