### PR TITLE
Implement caching for  updates

### DIFF
--- a/00_Base/src/index.ts
+++ b/00_Base/src/index.ts
@@ -412,7 +412,7 @@ export class OcpiServer extends KoaServer {
 
   private initContainer() {
     Container.set(OcpiConfigToken, this.ocpiConfig);
-    Container.set(CacheWrapper, new CacheWrapper(this.cache));
+    Container.set(CacheWrapper, new CacheWrapper(this.cache, this.logger));
     Container.set(Logger, this.logger);
 
     Container.set(

--- a/00_Base/src/mapper/SessionMapper.ts
+++ b/00_Base/src/mapper/SessionMapper.ts
@@ -319,6 +319,13 @@ export class SessionMapper extends BaseTransactionMapper {
     token: TokenDTO,
     tariff: ITariffDto,
   ): Session {
+    const beginMeterValue = transaction.meterValues?.find((mv) =>
+      mv.sampledValue.find(
+        (sv) =>
+          sv.context === OCPP2_0_1.ReadingContextEnumType.Transaction_Begin,
+      ),
+    );
+
     return {
       country_code: location.country_code,
       party_id: location.party_id,
@@ -340,10 +347,9 @@ export class SessionMapper extends BaseTransactionMapper {
       evse_uid: this.getEvseUid(transaction),
       connector_id: transaction.connectorId!.toString(),
       currency: tariff.currency,
-      charging_periods: this.getChargingPeriods(
-        transaction.meterValues,
-        String(tariff?.id),
-      ),
+      charging_periods: beginMeterValue
+        ? this.getChargingPeriods([beginMeterValue], String(tariff?.id))
+        : [],
       status: this.getTransactionStatus(transaction),
       last_updated: transaction.updatedAt!,
       // TODO: Fill in optional values

--- a/00_Base/src/trigger/CommandsClientApi.ts
+++ b/00_Base/src/trigger/CommandsClientApi.ts
@@ -23,7 +23,7 @@ export class CommandsClientApi extends BaseClientApi {
 
   constructor(@Inject() cacheWrapper: CacheWrapper) {
     super();
-    this.cache = cacheWrapper.cache;
+    this.cache = cacheWrapper.getCache();
   }
 
   CONTROLLER_PATH = ModuleId.Commands;

--- a/00_Base/src/util/CacheWrapper.ts
+++ b/00_Base/src/util/CacheWrapper.ts
@@ -3,11 +3,36 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ICache } from '@citrineos/base';
+import { Logger } from 'tslog';
 
 export class CacheWrapper {
-  cache: ICache;
+  constructor(
+    private readonly cache: ICache,
+    private readonly logger: Logger<any>,
+  ) {}
 
-  constructor(cache: ICache) {
-    this.cache = cache;
+  getCache(): ICache {
+    return this.cache;
+  }
+
+  async waitForCacheKey(
+    key: string,
+    timeoutMs: number = 30000,
+  ): Promise<boolean> {
+    if (await this.cache.get(key)) {
+      return true;
+    }
+
+    this.logger.info(`Waiting for cache key ${key}...`);
+
+    const result = await this.cache.onChange<string>(key, timeoutMs / 1000);
+
+    if (result) {
+      this.logger.info(`Cache key ${key} found.`);
+      return true;
+    } else {
+      this.logger.warn(`Timeout waiting for cache key ${key}`);
+      return false;
+    }
   }
 }

--- a/00_Base/src/util/CommandExecutor.ts
+++ b/00_Base/src/util/CommandExecutor.ts
@@ -58,7 +58,7 @@ export class CommandExecutor {
     @Inject() cacheWrapper: CacheWrapper,
     @InjectMany(OCPP_COMMAND_HANDLER) handlers: OCPPCommandHandler[],
   ) {
-    this.cache = cacheWrapper.cache;
+    this.cache = cacheWrapper.getCache();
     handlers.forEach((handler) => {
       this.handlerRegistry.set(handler.supportedVersion, handler);
     });


### PR DESCRIPTION
### Summary

This PR introduces a caching mechanism to ensure that OCPI session updates (PATCH requests) are only processed after their corresponding session creation (PUT request) has been broadcast. This resolves potential data integrity issues where updates could arrive before their base session exists.

### Key Changes

- SessionBroadcaster
  - Integrated a CacheWrapper to coordinate session creation and update broadcasts.
  - Added logic to cache session IDs on PUT and delay PATCH broadcasts until the session is cached.
  - Automatically removes cached keys when sessions reach COMPLETED status.
  - Added warnings for PATCH operations skipped due to cache timeouts.

- CacheWrapper (New Utility)
  - Provides a simple abstraction around the caching layer.
  - Implements waitForCacheKey() to wait for a key to exist within a configurable timeout (default: 30s).
  - Adds detailed logging for cache wait operations, hits, and timeouts.

- SessionMapper
  - Updated session creation logic to extract and use the beginMeterValue for accurate charging period mapping.
  - CommandsClientApi & CommandExecutor
