### PR TITLE
Fix proper OCPI 2.2.1 implementation as sender

### DIFF
--- a/00_Base/src/services/CredentialsService.ts
+++ b/00_Base/src/services/CredentialsService.ts
@@ -100,6 +100,10 @@ export class CredentialsService {
         `TenantPartner expects ${partner.partnerProfileOCPI!.version.version}, received ${versionNumber}`,
       );
     }
+    partner.partnerProfileOCPI!.credentials = {
+      versionsUrl: credentials.url,
+      token: credentials.token,
+    };
     const tenantPartner = await this.getVersionDetails(
       partner,
       credentials.url,
@@ -107,10 +111,6 @@ export class CredentialsService {
 
     const newServerToken = uuidv4();
     tenantPartner.partnerProfileOCPI!.serverCredentials.token = newServerToken;
-    tenantPartner.partnerProfileOCPI!.credentials = {
-      versionsUrl: credentials.url,
-      token: credentials.token,
-    };
     tenantPartner.partnerProfileOCPI!.roles = credentials.roles.map(
       (value: CredentialsRoleDTO) =>
         RegistrationMapper.toCredentialsRole(value),

--- a/00_Base/src/trigger/BaseClientApi.ts
+++ b/00_Base/src/trigger/BaseClientApi.ts
@@ -92,7 +92,7 @@ export abstract class BaseClientApi {
     const headers: IHeaders = {};
     headers[OcpiHttpHeader.XRequestId] = uuidv4();
     headers[OcpiHttpHeader.XCorrelationId] = uuidv4();
-    const token = partnerProfile.serverCredentials.token;
+    const token = partnerProfile.credentials?.token;
     if (!token) {
       throw new MissingRequiredParamException(
         'token',

--- a/00_Base/src/trigger/VersionsClientApi.ts
+++ b/00_Base/src/trigger/VersionsClientApi.ts
@@ -7,6 +7,7 @@ import { Service } from 'typedi';
 import { UnsuccessfulRequestException } from '../exception/UnsuccessfulRequestException.js';
 import type { VersionDetailsResponseDTO } from '../model/DTO/VersionDetailsResponseDTO.js';
 import { VersionDetailsResponseDTOSchema } from '../model/DTO/VersionDetailsResponseDTO.js';
+import { VersionListResponseDTOSchema } from '../model/DTO/VersionListResponseDTO.js';
 import type { VersionListResponseDTO } from '../model/DTO/VersionListResponseDTO.js';
 import { HttpMethod, type PartnerProfile } from '@citrineos/base';
 import { VersionsInterface } from '../model/EndpointIdentifier.js';
@@ -42,7 +43,7 @@ export class VersionsClientApi extends BaseClientApi {
         toCountryCode,
         toPartyId,
         HttpMethod.Get,
-        VersionDetailsResponseDTOSchema,
+        VersionListResponseDTOSchema,
         partnerProfile,
         false,
         url,


### PR DESCRIPTION
I found a few issues for OCPI 2.2.1 implementation:
1 - Token B must be set before making outgoing version requests
According to OCPI 2.2.1, Token B (received from the partner during registration) must be used to authenticate outgoing requests to GET /versions and GET /version-details. In the original implementation, credentials was being set on partnerProfileOCPI after Token C (called token B in the code) was generated, meaning it was not available on the profile when the version requests were made. This was inconsistent with the OCPI spec and with the role of credentials in this codebase (see Fix 2).

Fix: Token A is now stored in partnerProfileOCPI.credentials before getVersionDetails() is called, ensuring it is available as the outgoing auth token for GET /versions and GET /version-details.

2 - serverCredentials.token was used for outgoing request authentication
From my understanding of the codebase it follows this convention:
serverCredentials.token is the token we issue to our partner to authenticate their incoming requests to us
credentials.token is the token our partner issued to us, used to authenticate our outgoing requests to them

BaseClientApi.getHeaders() was using partnerProfile.serverCredentials.token to set the Authorization header on all outgoing HTTP calls, which is the wrong token — it was sending our own inbound token instead of the partner's token.

Fix: Changed getHeaders() to use partnerProfile.credentials?.token.

3 - Wrong schema used in VersionsClientApi.getVersions()
getVersions() was validating the CPO's response against VersionDetailsResponseDTOSchema, which expects data to be an This caused a runtime Zod validation crash:
 Expected object, received array at path data
Fix: Changed the schema passed to request() from VersionDetailsResponseDTOSchema to VersionListResponseDTOSchema, which correctly expects z.array(VersionDTOSchema). 

[](url)
<img width="678" height="502" alt="Screenshot_20260313_104212" src="https://github.com/user-attachments/assets/a3de3a54-3371-4c83-9ff9-dec4b212fd07" />
