### PR TITLE
FIX proper OCPI 2.2.1 implementation of TOKEN C

### DIFF
--- a/00_Base/src/services/CredentialsService.ts
+++ b/00_Base/src/services/CredentialsService.ts
@@ -234,7 +234,7 @@ export class CredentialsService {
       RegistrationMapper.tenantPartnerToCredentialsDto(tenantPartner),
     );
     if (!credentialsResponse?.data?.token) {
-      throw new NotFoundError('EMSP did not return Token C in credentials response');
+      throw new NotFoundError('Token C not found in credentials response');
     }
     
     // Replace Token A with Token C (OCPI spec requirement)

--- a/00_Base/src/services/CredentialsService.ts
+++ b/00_Base/src/services/CredentialsService.ts
@@ -236,7 +236,7 @@ export class CredentialsService {
     if (!credentialsResponse?.data?.token) {
       throw new NotFoundError('Token C not found in credentials response');
     }
-    
+
     // Replace Token A with Token C (OCPI spec requirement)
     tenantPartner.partnerProfileOCPI!.credentials = {
       versionsUrl: credentialsResponse.data.url,
@@ -246,7 +246,7 @@ export class CredentialsService {
       credentialsResponse.data.roles.map((value: CredentialsRoleDTO) =>
         RegistrationMapper.toCredentialsRole(value),
       );
-    
+
     await this.ocpiGraphqlClient.request<
       UpdateTenantPartnerProfileMutationResult,
       UpdateTenantPartnerProfileMutationVariables

--- a/00_Base/src/services/CredentialsService.ts
+++ b/00_Base/src/services/CredentialsService.ts
@@ -233,6 +233,27 @@ export class CredentialsService {
       tenantPartner.partnerProfileOCPI!,
       RegistrationMapper.tenantPartnerToCredentialsDto(tenantPartner),
     );
+    if (!credentialsResponse?.data?.token) {
+      throw new NotFoundError('EMSP did not return Token C in credentials response');
+    }
+    
+    // Replace Token A with Token C (OCPI spec requirement)
+    tenantPartner.partnerProfileOCPI!.credentials = {
+      versionsUrl: credentialsResponse.data.url,
+      token: credentialsResponse.data.token,
+    };
+    tenantPartner.partnerProfileOCPI!.roles =
+      credentialsResponse.data.roles.map((value: CredentialsRoleDTO) =>
+        RegistrationMapper.toCredentialsRole(value),
+      );
+    
+    await this.ocpiGraphqlClient.request<
+      UpdateTenantPartnerProfileMutationResult,
+      UpdateTenantPartnerProfileMutationVariables
+    >(UPDATE_TENANT_PARTNER_PROFILE, {
+      partnerId: tenantPartner.id!,
+      input: tenantPartner.partnerProfileOCPI!,
+    });
     return credentialsResponse.data as CredentialsDTO;
   }
 


### PR DESCRIPTION
During the OCPI 2.2.1 registration process where CitrineOS acts as the sender, registerCredentialsTokenA was not saving the Token C returned the receiver in its POST /credentials response.

Fix:
After successfully receiving the receiver credentials response, a second UPDATE_TENANT_PARTNER_PROFILE mutation is now issued in registerCredentialsTokenA to:
- Replace the stored client token (Token A → Token C).
- Update the stored versionsUrl and roles from the EMSP's response

<img width="678" height="502" alt="Screenshot_20260313_104212" src="https://github.com/user-attachments/assets/579e5a74-fb16-49d7-9949-777873f368e0" />
